### PR TITLE
P2-4: salvage task and approval domain models

### DIFF
--- a/src/waywarden/domain/approval.py
+++ b/src/waywarden/domain/approval.py
@@ -1,0 +1,122 @@
+"""Provider-neutral approval domain model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal, cast, get_args
+
+from waywarden.domain.ids import ApprovalId, RunId
+
+ApprovalState = Literal["pending", "granted", "denied", "timeout"]
+_VALID_STATES: frozenset[str] = frozenset(get_args(ApprovalState))
+
+
+def _require_non_empty_text(value: str, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+
+    trimmed = value.strip()
+    if not trimmed:
+        raise ValueError(f"{field_name} must not be blank")
+    return trimmed
+
+
+def _require_aware_datetime(value: datetime, *, field_name: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise TypeError(f"{field_name} must be a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    return value
+
+
+def _normalize_utc_datetime(value: datetime, *, field_name: str) -> datetime:
+    normalized = _require_aware_datetime(value, field_name=field_name)
+    return normalized.astimezone(UTC)
+
+
+def _normalize_state(value: ApprovalState | str) -> ApprovalState:
+    normalized = _require_non_empty_text(value, field_name="state")
+    if normalized not in _VALID_STATES:
+        raise ValueError("state must be one of 'pending', 'granted', 'denied', or 'timeout'")
+    return cast(ApprovalState, normalized)
+
+
+@dataclass(frozen=True, slots=True)
+class Approval:
+    """Immutable persisted approval decision artifact referenced by RT-002 events."""
+
+    id: ApprovalId
+    run_id: RunId
+    approval_kind: str
+    requested_capability: str | None
+    summary: str
+    state: ApprovalState
+    requested_at: datetime
+    decided_at: datetime | None
+    decided_by: str | None
+    expires_at: datetime | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "id",
+            ApprovalId(_require_non_empty_text(self.id, field_name="id")),
+        )
+        object.__setattr__(
+            self,
+            "run_id",
+            RunId(_require_non_empty_text(self.run_id, field_name="run_id")),
+        )
+        object.__setattr__(
+            self,
+            "approval_kind",
+            _require_non_empty_text(self.approval_kind, field_name="approval_kind"),
+        )
+        if self.requested_capability is not None:
+            object.__setattr__(
+                self,
+                "requested_capability",
+                _require_non_empty_text(
+                    self.requested_capability,
+                    field_name="requested_capability",
+                ),
+            )
+        object.__setattr__(
+            self,
+            "summary",
+            _require_non_empty_text(self.summary, field_name="summary"),
+        )
+        object.__setattr__(self, "state", _normalize_state(self.state))
+
+        requested_at = _require_aware_datetime(self.requested_at, field_name="requested_at")
+        object.__setattr__(self, "requested_at", requested_at)
+
+        decided_at = self.decided_at
+        if decided_at is not None:
+            decided_at = _require_aware_datetime(decided_at, field_name="decided_at")
+            if decided_at < requested_at:
+                raise ValueError("decided_at must not be before requested_at")
+            object.__setattr__(self, "decided_at", decided_at)
+
+        if self.decided_by is not None:
+            object.__setattr__(
+                self,
+                "decided_by",
+                _require_non_empty_text(self.decided_by, field_name="decided_by"),
+            )
+
+        if self.expires_at is not None:
+            object.__setattr__(
+                self,
+                "expires_at",
+                _normalize_utc_datetime(self.expires_at, field_name="expires_at"),
+            )
+
+        if self.state == "pending":
+            if self.decided_at is not None or self.decided_by is not None:
+                raise ValueError("pending approvals must not have decided_at or decided_by")
+            return
+
+        if self.decided_at is None:
+            raise ValueError("decided_at must be set once approval state is not pending")

--- a/src/waywarden/domain/ids.py
+++ b/src/waywarden/domain/ids.py
@@ -5,3 +5,6 @@ from typing import NewType
 InstanceId = NewType("InstanceId", str)
 SessionId = NewType("SessionId", str)
 MessageId = NewType("MessageId", str)
+TaskId = NewType("TaskId", str)
+ApprovalId = NewType("ApprovalId", str)
+RunId = NewType("RunId", str)

--- a/src/waywarden/domain/task.py
+++ b/src/waywarden/domain/task.py
@@ -1,0 +1,92 @@
+"""Provider-neutral task domain model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, cast, get_args
+
+from waywarden.domain.ids import SessionId, TaskId
+
+TaskState = Literal[
+    "draft",
+    "planning",
+    "executing",
+    "waiting_approval",
+    "completed",
+    "failed",
+    "cancelled",
+]
+_VALID_STATES: frozenset[str] = frozenset(get_args(TaskState))
+
+
+def _require_non_empty_text(value: str, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+
+    trimmed = value.strip()
+    if not trimmed:
+        raise ValueError(f"{field_name} must not be blank")
+    return trimmed
+
+
+def _require_aware_datetime(value: datetime, *, field_name: str) -> datetime:
+    if not isinstance(value, datetime):
+        raise TypeError(f"{field_name} must be a datetime")
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    return value
+
+
+def _normalize_state(value: TaskState | str) -> TaskState:
+    normalized = _require_non_empty_text(value, field_name="state")
+    if normalized not in _VALID_STATES:
+        raise ValueError(
+            "state must be one of 'draft', 'planning', 'executing', 'waiting_approval', "
+            "'completed', 'failed', or 'cancelled'"
+        )
+    return cast(TaskState, normalized)
+
+
+@dataclass(frozen=True, slots=True)
+class Task:
+    """Immutable task record aligned to the RT-002 run lifecycle."""
+
+    id: TaskId
+    session_id: SessionId
+    title: str
+    objective: str
+    state: TaskState
+    created_at: datetime
+    updated_at: datetime
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "id",
+            TaskId(_require_non_empty_text(self.id, field_name="id")),
+        )
+        object.__setattr__(
+            self,
+            "session_id",
+            SessionId(_require_non_empty_text(self.session_id, field_name="session_id")),
+        )
+        object.__setattr__(
+            self,
+            "title",
+            _require_non_empty_text(self.title, field_name="title"),
+        )
+        object.__setattr__(
+            self,
+            "objective",
+            _require_non_empty_text(self.objective, field_name="objective"),
+        )
+        object.__setattr__(self, "state", _normalize_state(self.state))
+
+        created_at = _require_aware_datetime(self.created_at, field_name="created_at")
+        updated_at = _require_aware_datetime(self.updated_at, field_name="updated_at")
+        if updated_at < created_at:
+            raise ValueError("updated_at must not be before created_at")
+
+        object.__setattr__(self, "created_at", created_at)
+        object.__setattr__(self, "updated_at", updated_at)

--- a/tests/domain/test_approval.py
+++ b/tests/domain/test_approval.py
@@ -1,0 +1,89 @@
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+from waywarden.domain.approval import Approval
+from waywarden.domain.ids import ApprovalId, RunId
+
+
+def test_approval_state_literal_enforced() -> None:
+    with pytest.raises(ValueError, match="state must be one of"):
+        Approval(
+            id=ApprovalId("approval-1"),
+            run_id=RunId("run-1"),
+            approval_kind="tool-call",
+            requested_capability="send_email",
+            summary="Request permission to send the release note",
+            state="approved",  # type: ignore[arg-type]
+            requested_at=datetime(2026, 4, 19, 14, 0, tzinfo=UTC),
+            decided_at=None,
+            decided_by=None,
+            expires_at=datetime(2026, 4, 19, 15, 0, tzinfo=UTC),
+        )
+
+
+def test_decided_fields_coherent_with_state() -> None:
+    with pytest.raises(
+        ValueError,
+        match="pending approvals must not have decided_at or decided_by",
+    ):
+        Approval(
+            id=ApprovalId("approval-1"),
+            run_id=RunId("run-1"),
+            approval_kind="tool-call",
+            requested_capability=None,
+            summary="Wait for operator approval",
+            state="pending",
+            requested_at=datetime(2026, 4, 19, 14, 0, tzinfo=UTC),
+            decided_at=datetime(2026, 4, 19, 14, 5, tzinfo=UTC),
+            decided_by="operator",
+            expires_at=datetime(2026, 4, 19, 15, 0, tzinfo=UTC),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="decided_at must be set once approval state is not pending",
+    ):
+        Approval(
+            id=ApprovalId("approval-2"),
+            run_id=RunId("run-2"),
+            approval_kind="tool-call",
+            requested_capability=None,
+            summary="Wait for operator approval",
+            state="granted",
+            requested_at=datetime(2026, 4, 19, 14, 0, tzinfo=UTC),
+            decided_at=None,
+            decided_by="operator",
+            expires_at=datetime(2026, 4, 19, 15, 0, tzinfo=UTC),
+        )
+
+
+def test_expires_at_must_be_timezone_aware_and_normalized_to_utc() -> None:
+    with pytest.raises(ValueError, match="expires_at must be timezone-aware"):
+        Approval(
+            id=ApprovalId("approval-1"),
+            run_id=RunId("run-1"),
+            approval_kind="tool-call",
+            requested_capability=None,
+            summary="Wait for operator approval",
+            state="pending",
+            requested_at=datetime(2026, 4, 19, 14, 0, tzinfo=UTC),
+            decided_at=None,
+            decided_by=None,
+            expires_at=datetime(2026, 4, 19, 15, 0),
+        )
+
+    approval = Approval(
+        id=ApprovalId("approval-2"),
+        run_id=RunId("run-2"),
+        approval_kind="tool-call",
+        requested_capability=None,
+        summary="Wait for operator approval",
+        state="pending",
+        requested_at=datetime(2026, 4, 19, 14, 0, tzinfo=UTC),
+        decided_at=None,
+        decided_by=None,
+        expires_at=datetime(2026, 4, 19, 11, 0, tzinfo=timezone(timedelta(hours=-4))),
+    )
+
+    assert approval.expires_at == datetime(2026, 4, 19, 15, 0, tzinfo=UTC)

--- a/tests/domain/test_ids.py
+++ b/tests/domain/test_ids.py
@@ -1,6 +1,6 @@
 from typing import assert_type
 
-from waywarden.domain.ids import InstanceId, MessageId, SessionId
+from waywarden.domain.ids import ApprovalId, InstanceId, MessageId, RunId, SessionId, TaskId
 
 
 def _needs_session_id(value: SessionId) -> SessionId:
@@ -15,11 +15,29 @@ def _needs_instance_id(value: InstanceId) -> InstanceId:
     return value
 
 
+def _needs_task_id(value: TaskId) -> TaskId:
+    return value
+
+
+def _needs_approval_id(value: ApprovalId) -> ApprovalId:
+    return value
+
+
+def _needs_run_id(value: RunId) -> RunId:
+    return value
+
+
 def test_newtypes_distinguish_at_type_level() -> None:
     session_id = SessionId("session-1")
     message_id = MessageId("message-1")
     instance_id = InstanceId("coding-main")
+    task_id = TaskId("task-1")
+    approval_id = ApprovalId("approval-1")
+    run_id = RunId("run-1")
 
     assert_type(_needs_session_id(session_id), SessionId)
     assert_type(_needs_message_id(message_id), MessageId)
     assert_type(_needs_instance_id(instance_id), InstanceId)
+    assert_type(_needs_task_id(task_id), TaskId)
+    assert_type(_needs_approval_id(approval_id), ApprovalId)
+    assert_type(_needs_run_id(run_id), RunId)

--- a/tests/domain/test_task.py
+++ b/tests/domain/test_task.py
@@ -1,0 +1,32 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from waywarden.domain.ids import SessionId, TaskId
+from waywarden.domain.task import Task
+
+
+def test_task_state_literal_enforced() -> None:
+    with pytest.raises(ValueError, match="state must be one of"):
+        Task(
+            id=TaskId("task-1"),
+            session_id=SessionId("session-1"),
+            title="Ship persistence domain",
+            objective="Model task records for RT-002-aligned execution",
+            state="queued",  # type: ignore[arg-type]
+            created_at=datetime(2026, 4, 19, 14, 0, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 19, 14, 1, tzinfo=UTC),
+        )
+
+
+def test_updated_at_not_before_created_at() -> None:
+    with pytest.raises(ValueError, match="updated_at must not be before created_at"):
+        Task(
+            id=TaskId("task-1"),
+            session_id=SessionId("session-1"),
+            title="Ship persistence domain",
+            objective="Model task records for RT-002-aligned execution",
+            state="draft",
+            created_at=datetime(2026, 4, 19, 14, 1, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 19, 14, 0, tzinfo=UTC),
+        )


### PR DESCRIPTION
## Summary
- salvage only the net-new P2-4 work from the stale `issue-39-p2-4-task-approval` branch
- add provider-neutral `Task` and `Approval` domain models
- extend opaque id types and add focused model/id tests

## Why
The old branch was 20 commits behind `main` and also contained already-superseded P2-2/P2-3 history. This PR replays only the missing P2-4 delta onto current `main`.
