### PR TITLE
P3-1: Provider protocols (#52)

### DIFF
--- a/src/waywarden/domain/providers/__init__.py
+++ b/src/waywarden/domain/providers/__init__.py
@@ -1,0 +1,26 @@
+"""Provider-neutral protocol definitions for Waywarden's adapter layer.
+
+Every Protocol is ``@runtime_checkable`` so that concrete adapters can be
+validated at startup without importing provider SDKs.
+
+See ADR-0001 (context), ADR-0003 (memory vs knowledge), ADR-0005 (approval
+model), and ADR-0011 (harness boundaries).
+"""
+
+from __future__ import annotations
+
+from waywarden.domain.providers.channel import ChannelProvider
+from waywarden.domain.providers.knowledge import KnowledgeProvider
+from waywarden.domain.providers.memory import MemoryProvider
+from waywarden.domain.providers.model import ModelProvider
+from waywarden.domain.providers.tool import ToolProvider
+from waywarden.domain.providers.tracer import TracerProvider
+
+__all__ = [
+    "ChannelProvider",
+    "KnowledgeProvider",
+    "MemoryProvider",
+    "ModelProvider",
+    "ToolProvider",
+    "TracerProvider",
+]

--- a/src/waywarden/domain/providers/channel.py
+++ b/src/waywarden/domain/providers/channel.py
@@ -1,0 +1,16 @@
+"""Channel provider protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from waywarden.domain.providers.types.channel import ChannelMessage, ChannelSendResult
+
+
+@runtime_checkable
+class ChannelProvider(Protocol):
+    """Protocol for channel providers."""
+
+    async def send(self, message: ChannelMessage) -> ChannelSendResult: ...
+
+    def name(self) -> str: ...

--- a/src/waywarden/domain/providers/knowledge.py
+++ b/src/waywarden/domain/providers/knowledge.py
@@ -1,0 +1,25 @@
+"""Knowledge provider protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from waywarden.domain.providers.types.knowledge import KnowledgeDocument, KnowledgeHit
+
+
+@runtime_checkable
+class KnowledgeProvider(Protocol):
+    """Protocol for knowledge providers.
+
+    Memory and knowledge are kept distinct (ADR-0003): this Protocol
+    does not inherit from any shared base.
+    """
+
+    async def search(
+        self,
+        query: str,
+        *,
+        limit: int = 10,
+    ) -> list[KnowledgeHit]: ...
+
+    async def fetch(self, ref: str) -> KnowledgeDocument: ...

--- a/src/waywarden/domain/providers/memory.py
+++ b/src/waywarden/domain/providers/memory.py
@@ -1,0 +1,25 @@
+"""Memory provider protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from waywarden.domain.ids import SessionId
+from waywarden.domain.providers.types.memory import MemoryEntry, MemoryEntryRef, MemoryQuery
+
+
+@runtime_checkable
+class MemoryProvider(Protocol):
+    """Protocol for memory providers.
+
+    Memory and knowledge are kept distinct (ADR-0003): this Protocol
+    does not inherit from any shared base.
+    """
+
+    async def write(self, session_id: SessionId, entry: MemoryEntry) -> MemoryEntryRef: ...
+
+    async def read(
+        self,
+        session_id: SessionId,
+        query: MemoryQuery,
+    ) -> list[MemoryEntry]: ...

--- a/src/waywarden/domain/providers/model.py
+++ b/src/waywarden/domain/providers/model.py
@@ -1,0 +1,25 @@
+"""Model provider protocol."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from waywarden.domain.providers.types.model import ModelCompletion, PromptEnvelope
+from waywarden.domain.providers.types.tool import ToolDecl
+
+
+@runtime_checkable
+class ModelProvider(Protocol):
+    """Protocol for model completion providers.
+
+    All provider SDK types must stay out of this module.
+    """
+
+    async def complete(
+        self,
+        prompt: PromptEnvelope,
+        *,
+        tools: Sequence[ToolDecl] = (),
+        stream: bool = False,
+    ) -> ModelCompletion: ...

--- a/src/waywarden/domain/providers/tool.py
+++ b/src/waywarden/domain/providers/tool.py
@@ -1,0 +1,22 @@
+"""Tool provider protocol."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol, runtime_checkable
+
+from waywarden.domain.providers.types.tool import ToolResult
+
+
+@runtime_checkable
+class ToolProvider(Protocol):
+    """Protocol for tool providers."""
+
+    async def invoke(
+        self,
+        tool_id: str,
+        action: str,
+        params: Mapping[str, object],
+    ) -> ToolResult: ...
+
+    def capabilities(self) -> frozenset[str]: ...

--- a/src/waywarden/domain/providers/tracer.py
+++ b/src/waywarden/domain/providers/tracer.py
@@ -1,0 +1,21 @@
+"""Tracer provider protocol.
+
+Re-exports the ``Tracer`` / ``Span`` shapes from the infra tracing layer
+under the provider namespace for consistency (ADR-0011).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from waywarden.infra.tracing.base import Tracer
+
+
+@runtime_checkable
+class TracerProvider(Protocol):
+    """Protocol for tracer providers.
+
+    The concrete adapter is the one from P2-12 (#47).
+    """
+
+    def get_tracer(self, name: str) -> Tracer: ...

--- a/src/waywarden/domain/providers/types/__init__.py
+++ b/src/waywarden/domain/providers/types/__init__.py
@@ -1,0 +1,43 @@
+"""Provider-neutral value types for the provider protocol layer.
+
+All value types are frozen dataclasses with slots for memory efficiency.
+No provider SDK types leak into this package.
+"""
+
+from __future__ import annotations
+
+from waywarden.domain.providers.types.channel import (
+    ChannelMessage,
+    ChannelSendResult,
+)
+from waywarden.domain.providers.types.knowledge import (
+    KnowledgeDocument,
+    KnowledgeHit,
+)
+from waywarden.domain.providers.types.memory import (
+    MemoryEntry,
+    MemoryEntryRef,
+    MemoryQuery,
+)
+from waywarden.domain.providers.types.model import (
+    ModelCompletion,
+    PromptEnvelope,
+)
+from waywarden.domain.providers.types.tool import (
+    ToolDecl,
+    ToolResult,
+)
+
+__all__ = [
+    "ChannelMessage",
+    "ChannelSendResult",
+    "KnowledgeDocument",
+    "KnowledgeHit",
+    "MemoryEntry",
+    "MemoryEntryRef",
+    "MemoryQuery",
+    "ModelCompletion",
+    "PromptEnvelope",
+    "ToolDecl",
+    "ToolResult",
+]

--- a/src/waywarden/domain/providers/types/channel.py
+++ b/src/waywarden/domain/providers/types/channel.py
@@ -1,0 +1,36 @@
+"""Value types for the channel provider protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ChannelMessage:
+    """A message sent through a channel provider."""
+
+    channel_name: str
+    content: str
+    metadata: dict[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.content, str):
+            raise TypeError("content must be a string")
+        if self.metadata is not None and not isinstance(self.metadata, dict):
+            raise TypeError("metadata must be a dict or None")
+
+
+@dataclass(frozen=True, slots=True)
+class ChannelSendResult:
+    """Result of sending a message through a channel."""
+
+    channel_name: str
+    delivered: bool
+    message_id: str | None = None
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.channel_name, str):
+            raise TypeError("channel_name must be a string")
+        if self.error is not None and not isinstance(self.error, str):
+            raise TypeError("error must be a string or None")

--- a/src/waywarden/domain/providers/types/knowledge.py
+++ b/src/waywarden/domain/providers/types/knowledge.py
@@ -1,0 +1,31 @@
+"""Value types for the knowledge provider protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class KnowledgeHit:
+    """A single match returned by a knowledge search."""
+
+    ref: str
+    title: str
+    snippet: str
+    score: float
+
+
+@dataclass(frozen=True, slots=True)
+class KnowledgeDocument:
+    """A full knowledge document fetched by reference."""
+
+    ref: str
+    title: str
+    content: str
+    metadata: dict[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.content, str):
+            raise TypeError("content must be a string")
+        if self.metadata is not None and not isinstance(self.metadata, dict):
+            raise TypeError("metadata must be a dict or None")

--- a/src/waywarden/domain/providers/types/memory.py
+++ b/src/waywarden/domain/providers/types/memory.py
@@ -1,0 +1,62 @@
+"""Value types for the memory provider protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from waywarden.domain.ids import SessionId
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryEntryRef:
+    """Opaque reference to a stored memory entry."""
+
+    entry_id: str
+    session_id: SessionId
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryQuery:
+    """Parameters for a memory read operation."""
+
+    session_id: SessionId
+    query_text: str
+    limit: int = 10
+
+    def __post_init__(self) -> None:
+        if not self.session_id:
+            raise ValueError("session_id must not be empty")
+        if not isinstance(self.query_text, str):
+            raise TypeError("query_text must be a string")
+        if self.limit < 1:
+            raise ValueError("limit must be >= 1")
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryEntry:
+    """A single memory entry stored by the memory provider."""
+
+    session_id: SessionId
+    content: str
+    metadata: dict[str, str] = field(default_factory=dict)
+    created_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if not self.session_id:
+            raise ValueError("session_id must not be empty")
+        if not isinstance(self.content, str):
+            raise TypeError("content must be a string")
+        if not isinstance(self.metadata, dict):
+            raise TypeError("metadata must be a dict")
+        for k, v in self.metadata.items():
+            if not isinstance(k, str) or not isinstance(v, str):
+                raise TypeError("metadata keys and values must be strings")
+        if self.created_at is None:
+            object.__setattr__(self, "created_at", datetime.now(UTC))
+        elif not isinstance(self.created_at, datetime):
+            raise TypeError("created_at must be a datetime")
+        else:
+            if self.created_at.tzinfo is None or self.created_at.utcoffset() is None:
+                raise ValueError("created_at must be timezone-aware")
+            object.__setattr__(self, "created_at", self.created_at.astimezone(UTC))

--- a/src/waywarden/domain/providers/types/model.py
+++ b/src/waywarden/domain/providers/types/model.py
@@ -1,0 +1,60 @@
+"""Value types for the model provider protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from waywarden.domain.ids import SessionId
+
+
+@dataclass(frozen=True, slots=True)
+class PromptEnvelope:
+    """A provider-neutral prompt sent to a model."""
+
+    session_id: SessionId
+    messages: list[str]
+    tools: list[str] | None = None
+    system_prompt: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.session_id:
+            raise ValueError("session_id must not be empty")
+        if not self.messages:
+            raise ValueError("messages must not be empty")
+        for m in self.messages:
+            if not isinstance(m, str):
+                raise TypeError("each message must be a string")
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCompletion:
+    """Response from a model completion call."""
+
+    session_id: SessionId
+    text: str
+    model: str
+    provider: str
+    recorded_at: datetime
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.session_id:
+            raise ValueError("session_id must not be empty")
+        if not isinstance(self.text, str):
+            raise TypeError("text must be a string")
+        if not isinstance(self.model, str) or not self.model.strip():
+            raise ValueError("model must be a non-empty string")
+        if not isinstance(self.provider, str) or not self.provider.strip():
+            raise ValueError("provider must be a non-empty string")
+        if self.prompt_tokens < 0 or self.completion_tokens < 0:
+            raise ValueError("token counts must be non-negative")
+        if self.total_tokens != self.prompt_tokens + self.completion_tokens:
+            raise ValueError("total_tokens must equal prompt_tokens + completion_tokens")
+        if not isinstance(self.recorded_at, datetime):
+            raise TypeError("recorded_at must be a datetime")
+        if self.recorded_at.tzinfo is None or self.recorded_at.utcoffset() is None:
+            raise ValueError("recorded_at must be timezone-aware")
+        object.__setattr__(self, "recorded_at", self.recorded_at.astimezone(UTC))

--- a/src/waywarden/domain/providers/types/tool.py
+++ b/src/waywarden/domain/providers/types/tool.py
@@ -1,0 +1,45 @@
+"""Value types for the tool provider protocol."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ToolDecl:
+    """Declaration of a tool available for model invocation."""
+
+    tool_id: str
+    action: str
+    description: str
+    parameters: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.tool_id.strip():
+            raise ValueError("tool_id must not be empty")
+        if not self.action.strip():
+            raise ValueError("action must not be empty")
+        if not isinstance(self.description, str):
+            raise TypeError("description must be a string")
+
+
+@dataclass(frozen=True, slots=True)
+class ToolResult:
+    """Result of invoking a tool."""
+
+    tool_id: str
+    action: str
+    output: str
+    success: bool = True
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.tool_id.strip():
+            raise ValueError("tool_id must not be empty")
+        if not self.action.strip():
+            raise ValueError("action must not be empty")
+        if not isinstance(self.output, str):
+            raise TypeError("output must be a string")
+        if self.error is not None and not isinstance(self.error, str):
+            raise TypeError("error must be a string or None")

--- a/tests/domain/providers/test_memory_vs_knowledge_distinct.py
+++ b/tests/domain/providers/test_memory_vs_knowledge_distinct.py
@@ -1,0 +1,32 @@
+"""Test that MemoryProvider and KnowledgeProvider do not share a base Protocol.
+
+ADR-0003 requires memory and knowledge to stay distinct.
+"""
+
+from __future__ import annotations
+
+from typing import Generic, Protocol
+
+from waywarden.domain.providers.knowledge import KnowledgeProvider
+from waywarden.domain.providers.memory import MemoryProvider
+
+
+def test_no_shared_base() -> None:
+    """MemoryProvider and KnowledgeProvider must share only Protocol, Generic,
+    and object in their MRO — no shared base class or Protocol."""
+    memory_bases = set(MemoryProvider.__mro__)
+    knowledge_bases = set(KnowledgeProvider.__mro__)
+
+    shared = memory_bases & knowledge_bases
+    allowed = {
+        MemoryProvider,
+        KnowledgeProvider,
+        Protocol,
+        Generic,
+        object,
+    }
+
+    extra = shared - allowed
+    assert not extra, (
+        f"MemoryProvider and KnowledgeProvider share unexpected bases: {extra}"
+    )

--- a/tests/domain/providers/test_no_sdk_imports.py
+++ b/tests/domain/providers/test_no_sdk_imports.py
@@ -1,0 +1,74 @@
+"""Static scan to ensure domain/providers/ imports no provider SDKs."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+
+def _get_provider_package_root() -> Path:
+    domain_providers = importlib.import_module("waywarden.domain.providers")
+    return Path(domain_providers.__file__).parent
+
+
+_SDK_PACKAGES = ("openai", "anthropic", "httpx", "langchain", "litellm")
+
+
+def _scan_file(filepath: Path) -> list[str]:
+    """Return list of top-level imports found in *filepath*."""
+    try:
+        source = filepath.read_text(encoding="utf-8")
+        tree = ast.parse(source, filepath.name)
+    except (OSError, SyntaxError):
+        return []
+
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.module and not node.module.startswith(
+            "waywarden"
+        ):
+            imports.append(node.module.split(".")[0])
+    return imports
+
+
+def test_domain_has_no_sdk_imports() -> None:
+    """No file under src/waywarden/domain/providers/ may import a provider SDK."""
+    root = _get_provider_package_root()
+    found_violations: list[str] = []
+
+    for modname in _collect_module_names(root):
+        filepath = root / (modname.replace(".", "/") + ".py")
+        if not filepath.exists():
+            continue
+        imports = _scan_file(filepath)
+        for imp in imports:
+            if imp in _SDK_PACKAGES:
+                found_violations.append(f"{filepath.name}: imports {imp}")
+
+    assert not found_violations, (
+        "Provider domain files must not import provider SDKs:\n"
+        + "\n".join(found_violations)
+    )
+
+
+def _collect_module_names(root: Path) -> list[str]:
+    """Walk the package directory and return .py module names relative to root."""
+    names: list[str] = []
+    for filepath in root.rglob("*.py"):
+        if filepath.name == "__init__.py":
+            rel = filepath.relative_to(root)
+            parts = list(rel.parts)
+            if parts[-1] == "__init__.py":
+                parts = parts[:-1]
+            if parts:
+                names.append(".".join(parts))
+        else:
+            rel = filepath.relative_to(root)
+            parts = list(rel.parts)
+            parts[-1] = parts[-1][:-3]  # strip .py
+            names.append(".".join(parts))
+    return names

--- a/tests/domain/providers/test_protocols.py
+++ b/tests/domain/providers/test_protocols.py
@@ -1,0 +1,36 @@
+"""Test that all provider protocols are @runtime_checkable."""
+
+from __future__ import annotations
+
+import pytest
+
+from waywarden.domain.providers import (
+    ChannelProvider,
+    KnowledgeProvider,
+    MemoryProvider,
+    ModelProvider,
+    ToolProvider,
+    TracerProvider,
+)
+
+
+@pytest.mark.asyncio
+async def test_all_protocols_runtime_checkable() -> None:
+    """Every Protocol must be @runtime_checkable so that isinstance checks
+    work at startup without importing provider SDKs."""
+    for proto in (
+        ModelProvider,
+        MemoryProvider,
+        KnowledgeProvider,
+        ToolProvider,
+        ChannelProvider,
+        TracerProvider,
+    ):
+        # Verify the class is a Protocol subclass
+        assert hasattr(proto, "__protocol_attrs__") or hasattr(
+            proto, "__protocol__"
+        ), f"{proto.__name__} should be a Protocol"
+        # Verify it is marked runtime_checkable via the internal flag
+        assert getattr(proto, "_is_runtime_protocol", False), (
+            f"{proto.__name__} must be @runtime_checkable"
+        )

--- a/tests/domain/providers/test_types.py
+++ b/tests/domain/providers/test_types.py
@@ -1,0 +1,90 @@
+"""Test that all provider value types are frozen dataclasses."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from waywarden.domain.providers.types.channel import ChannelMessage, ChannelSendResult
+from waywarden.domain.providers.types.knowledge import KnowledgeDocument, KnowledgeHit
+from waywarden.domain.providers.types.memory import MemoryEntry, MemoryEntryRef, MemoryQuery
+from waywarden.domain.providers.types.model import ModelCompletion, PromptEnvelope
+from waywarden.domain.providers.types.tool import ToolDecl, ToolResult
+
+
+def _assert_frozen(cls: type) -> None:
+    """Verify the dataclass was declared with frozen=True."""
+    params = getattr(cls, "__dataclass_params__", None)
+    assert params is not None, f"{cls.__name__} is not a dataclass"
+    assert params.frozen, f"{cls.__name__} must be frozen"
+
+
+def test_value_types_are_frozen() -> None:
+    """All value types must be frozen dataclasses."""
+    for cls in (
+        PromptEnvelope,
+        ModelCompletion,
+        MemoryEntry,
+        MemoryEntryRef,
+        MemoryQuery,
+        KnowledgeHit,
+        KnowledgeDocument,
+        ToolDecl,
+        ToolResult,
+        ChannelMessage,
+        ChannelSendResult,
+    ):
+        _assert_frozen(cls)
+
+
+def test_prompt_envelope_rejects_empty_session() -> None:
+    with pytest.raises(ValueError, match="session_id"):
+        PromptEnvelope(session_id="", messages=["hello"])
+
+
+def test_prompt_envelope_rejects_empty_messages() -> None:
+    with pytest.raises(ValueError, match="messages"):
+        PromptEnvelope(session_id="s1", messages=[])
+
+
+def test_model_completion_rejects_negative_tokens() -> None:
+    with pytest.raises(ValueError, match="token counts"):
+        ModelCompletion(
+            session_id="s1",
+            text="hi",
+            model="test",
+            provider="test",
+            recorded_at=datetime.now(UTC),
+            prompt_tokens=-1,
+        )
+
+
+def test_model_completion_rejects_mismatched_total() -> None:
+    with pytest.raises(ValueError, match="total_tokens"):
+        ModelCompletion(
+            session_id="s1",
+            text="hi",
+            model="test",
+            provider="test",
+            recorded_at=datetime.now(UTC),
+            prompt_tokens=5,
+            completion_tokens=3,
+            total_tokens=100,
+        )
+
+
+def test_memory_entry_autosets_created_at() -> None:
+    entry = MemoryEntry(session_id="s1", content="hello")
+    assert entry.created_at is not None
+
+
+def test_tool_decl_rejects_empty_tool_id() -> None:
+    with pytest.raises(ValueError, match="tool_id"):
+        ToolDecl(tool_id="", action="run", description="test")
+
+
+def test_tool_result_defaults_success() -> None:
+    result = ToolResult(tool_id="t1", action="run", output="ok")
+    assert result.success is True
+    assert result.error is None


### PR DESCRIPTION
## Summary

Implements P3-1: Provider protocols for the model, memory, knowledge, tool, channel, and tracer provider surfaces.

- Introduces `@runtime_checkable` Protocol definitions under `src/waywarden/domain/providers/`
- Creates frozen dataclass value types under `src/waywarden/domain/providers/types/`
- No provider SDK imports in domain code (verified by static scan test)
- MemoryProvider and KnowledgeProvider share no base (ADR-0003 enforcement)
- All signatures typecheck under `mypy --strict`
- 11 issue-level tests covering all acceptance criteria

## Test file
- `tests/domain/providers/test_protocols.py` — all protocols are @runtime_checkable
- `tests/domain/providers/test_no_sdk_imports.py` — static scan for SDK imports
- `tests/domain/providers/test_memory_vs_knowledge_distinct.py` — ADR-0003 enforcement
- `tests/domain/providers/test_types.py` — frozen dataclass + validation tests

## Files changed
- `src/waywarden/domain/providers/__init__.py`
- `src/waywarden/domain/providers/channel.py`
- `src/waywarden/domain/providers/knowledge.py`
- `src/waywarden/domain/providers/memory.py`
- `src/waywarden/domain/providers/model.py`
- `src/waywarden/domain/providers/tool.py`
- `src/waywarden/domain/providers/tracer.py`
- `src/waywarden/domain/providers/types/__init__.py`
- `src/waywarden/domain/providers/types/channel.py`
- `src/waywarden/domain/providers/types/knowledge.py`
- `src/waywarden/domain/providers/types/memory.py`
- `src/waywarden/domain/providers/types/model.py`
- `src/waywarden/domain/providers/types/tool.py`
- `tests/domain/providers/test_*.py` (4 files)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>