### PR TITLE
P4-2: Channel adapter base + web channel (#65)

### DIFF
--- a/src/waywarden/adapters/channel/__init__.py
+++ b/src/waywarden/adapters/channel/__init__.py
@@ -1,0 +1,17 @@
+"""Channel adapter sub-package.
+
+Exports concrete channel adapters and their base infrastructure.
+"""
+
+from __future__ import annotations
+
+from waywarden.adapters.channel.base import ChannelAdapterBase
+from waywarden.adapters.channel.errors import ChannelRejectedError, ChannelTransportError
+from waywarden.adapters.channel.web import WebChannel
+
+__all__ = [
+    "ChannelAdapterBase",
+    "ChannelRejectedError",
+    "ChannelTransportError",
+    "WebChannel",
+]

--- a/src/waywarden/adapters/channel/base.py
+++ b/src/waywarden/adapters/channel/base.py
@@ -1,0 +1,48 @@
+"""Channel adapter base class.
+
+Provides a shared abstract base for channel adapters that bind transport
+to domain calls.  Channel adapters must never access repositories directly —
+business logic belongs in orchestrators / services, not adapters.
+
+See ADR-0011 for adapter boundary rules.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from waywarden.domain.providers.channel import ChannelProvider
+
+if TYPE_CHECKING:
+    from waywarden.domain.providers.types.channel import ChannelMessage, ChannelSendResult
+
+
+class ChannelAdapterBase(ABC, ChannelProvider):
+    """Abstract base for channel adapters.
+
+    Parameters
+    ----------
+    name:
+        Stable identifier for this channel (e.g. ``"web"``).
+    """
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self._logger: logging.Logger | None = None
+
+    @abstractmethod
+    async def send(self, message: ChannelMessage) -> ChannelSendResult: ...
+
+    def name(self) -> str:
+        return self._name
+
+    def _setup_logger(self) -> logging.Logger:
+        """Instantiate the adapter-local logger.
+
+        Returns the logger so callers can propagate structured fields.
+        """
+        if self._logger is None:
+            self._logger = logging.getLogger(f"waywarden.channel.{self._name}")
+        return self._logger

--- a/src/waywarden/adapters/channel/errors.py
+++ b/src/waywarden/adapters/channel/errors.py
@@ -1,0 +1,18 @@
+"""Channel adapter error types."""
+
+from __future__ import annotations
+
+
+class ChannelTransportError(Exception):
+    """Raised when a channel transport operation fails."""
+
+    def __init__(self, message: str, *, original: Exception | None = None) -> None:
+        super().__init__(message)
+        self.original = original
+
+
+class ChannelRejectedError(Exception):
+    """Raised when the destination rejects the message."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)

--- a/src/waywarden/adapters/channel/web.py
+++ b/src/waywarden/adapters/channel/web.py
@@ -1,0 +1,95 @@
+"""Web channel adapter.
+
+Delivers messages to an HTTP webhook configured in ``AppConfig``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from waywarden.adapters.channel.base import ChannelAdapterBase
+from waywarden.adapters.channel.errors import ChannelRejectedError
+from waywarden.domain.providers.types.channel import ChannelMessage, ChannelSendResult
+
+logger = logging.getLogger("waywarden.channel.web")
+
+
+class WebChannel(ChannelAdapterBase):
+    """Sends channel messages via HTTP POST to a webhook URL.
+
+    Parameters
+    ----------
+    webhook_url:
+        The target URL for delivering messages.
+    timeout:
+        Request timeout in seconds (default 5).
+    """
+
+    CHANNEL_NAME = "web"
+
+    def __init__(self, webhook_url: str, *, timeout: float = 5.0) -> None:
+        super().__init__(name=self.CHANNEL_NAME)
+        self._webhook_url = webhook_url
+        self._timeout = timeout
+        self._client = httpx.AsyncClient(timeout=self._timeout)
+
+    async def send(self, message: ChannelMessage) -> ChannelSendResult:
+        if message.channel_name != self._name:
+            raise ChannelRejectedError(
+                f"message channel {message.channel_name!r} does not match adapter {self._name!r}"
+            )
+
+        payload: dict[str, Any] = {
+            "content": message.content,
+        }
+        if message.metadata:
+            payload["metadata"] = message.metadata
+
+        try:
+            response = await self._client.post(
+                self._webhook_url,
+                json=payload,
+                headers={"Content-Type": "application/json"},
+            )
+        except httpx.RequestError as exc:
+            logger.warning("web transport error posting to %s: %s", self._webhook_url, exc)
+            return ChannelSendResult(
+                channel_name=self._name,
+                delivered=False,
+                error=str(exc),
+            )
+
+        if response.status_code == 200:
+            return ChannelSendResult(
+                channel_name=self._name,
+                delivered=True,
+                message_id=str(response.status_code),
+            )
+
+        if 400 <= response.status_code < 500:
+            raise ChannelRejectedError(
+                f"webhook rejected message: {response.status_code}"
+            )
+
+        return ChannelSendResult(
+            channel_name=self._name,
+            delivered=False,
+            error=f"unexpected status {response.status_code}",
+        )
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    def __del__(self) -> None:
+        """Best-effort cleanup of the underlying HTTP client on GC."""
+        try:
+            if not hasattr(self, "_client"):
+                return
+            if getattr(self._client, "is_closed", True):
+                return
+        except Exception:  # pragma: no cover
+            pass

--- a/src/waywarden/config/settings.py
+++ b/src/waywarden/config/settings.py
@@ -55,6 +55,7 @@ class AppConfig(BaseSettings):
     policy_overrides_path: Path | None = None
     active_instance: str | None = None
     instances_path: Path = Path("config/instances")
+    web_channel_webhook_url: str | None = None
 
     model_config = SettingsConfigDict(
         env_prefix="WAYWARDEN_",

--- a/tests/adapters/channel/test_no_repo_imports.py
+++ b/tests/adapters/channel/test_no_repo_imports.py
@@ -1,0 +1,48 @@
+"""Static scan to ensure channel adapters never import repositories.
+
+Channel adapters must stay transport-bound and never leak into domain
+repositories or the DB layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_CHANNELS_ROOT = (
+    Path(__file__).resolve().parent.parent.parent
+    / "waywarden"
+    / "adapters"
+    / "channel"
+)
+
+_REPO_IMPORT_PATHS = (
+    "waywarden.domain.repositories",
+    "waywarden.infra.db",
+)
+
+
+def _scan_file_for_imports(filepath: Path) -> list[str]:
+    """Return list of matched forbidden import prefixes found in *filepath*."""
+    found: list[str] = []
+    content = filepath.read_text(encoding="utf-8")
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        for prefix in _REPO_IMPORT_PATHS:
+            if prefix in stripped:
+                found.append(f"{filepath.name}:{stripped}")
+    return found
+
+
+def test_channels_have_no_repo_imports() -> None:
+    bad_lines: list[str] = []
+    for source_file in sorted(_CHANNELS_ROOT.glob("*.py")):
+        violations = _scan_file_for_imports(source_file)
+        bad_lines.extend(violations)
+
+    if bad_lines:
+        header = "Channel adapters must not import repositories or DB modules."
+        lines = [header]
+        lines.extend(f"- {v}" for v in bad_lines)
+        raise AssertionError("\n".join(lines))

--- a/tests/adapters/channel/test_web.py
+++ b/tests/adapters/channel/test_web.py
@@ -1,0 +1,170 @@
+"""Tests for the web channel adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from waywarden.adapters.channel.base import ChannelAdapterBase
+from waywarden.adapters.channel.errors import ChannelRejectedError
+from waywarden.adapters.channel.web import WebChannel
+from waywarden.domain.providers import ChannelProvider
+from waywarden.domain.providers.types.channel import ChannelMessage
+
+
+async def test_send_posts_to_webhook() -> None:
+    webhook_url = "http://example.com/webhook"
+
+    mock_response = httpx.Response(
+        status_code=200,
+        request=httpx.Request("POST", webhook_url),
+    )
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.is_closed = True
+        mock_client_cls.return_value = mock_client
+
+        channel = WebChannel(webhook_url=webhook_url)
+
+        message = ChannelMessage(channel_name="web", content="Hello")
+        result = await channel.send(message)
+
+        assert isinstance(channel, ChannelProvider)
+        assert isinstance(channel, ChannelAdapterBase)
+        assert channel.name() == "web"
+        assert result.delivered is True
+        assert result.error is None
+        mock_client.post.assert_called_once_with(
+            webhook_url,
+            json={"content": "Hello"},
+            headers={"Content-Type": "application/json"},
+        )
+
+        await channel.close()
+
+
+async def test_send_with_metadata() -> None:
+    webhook_url = "http://example.com/webhook"
+
+    mock_response = httpx.Response(
+        status_code=200,
+        request=httpx.Request("POST", webhook_url),
+    )
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.is_closed = True
+        mock_client_cls.return_value = mock_client
+
+        channel = WebChannel(webhook_url=webhook_url)
+
+        message = ChannelMessage(
+            channel_name="web",
+            content="Hello",
+            metadata={"source": "test"},
+        )
+        result = await channel.send(message)
+
+        assert result.delivered is True
+        call_args = mock_client.post.call_args
+        assert call_args[1]["json"]["metadata"] == {"source": "test"}
+
+        await channel.close()
+
+
+async def test_transport_error_surfaces() -> None:
+    webhook_url = "http://example.com/webhook"
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+        mock_client.is_closed = True
+        mock_client_cls.return_value = mock_client
+
+        channel = WebChannel(webhook_url=webhook_url)
+
+        message = ChannelMessage(channel_name="web", content="Hello")
+        result = await channel.send(message)
+
+        assert result.delivered is False
+        assert result.error == "connection refused"
+
+        await channel.close()
+
+
+async def test_rejected_error_on_4xx() -> None:
+    webhook_url = "http://example.com/webhook"
+
+    mock_response = httpx.Response(
+        status_code=400,
+        request=httpx.Request("POST", webhook_url),
+    )
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.is_closed = True
+        mock_client_cls.return_value = mock_client
+
+        channel = WebChannel(webhook_url=webhook_url)
+
+        message = ChannelMessage(channel_name="web", content="Hello")
+
+        with pytest.raises(ChannelRejectedError, match="webhook rejected"):
+            await channel.send(message)
+
+        await channel.close()
+
+
+async def test_unhandled_status_returns_failed_result() -> None:
+    webhook_url = "http://example.com/webhook"
+
+    mock_response = httpx.Response(
+        status_code=503,
+        request=httpx.Request("POST", webhook_url),
+    )
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.is_closed = True
+        mock_client_cls.return_value = mock_client
+
+        channel = WebChannel(webhook_url=webhook_url)
+
+        message = ChannelMessage(channel_name="web", content="Hello")
+        result = await channel.send(message)
+
+        assert result.delivered is False
+        assert "503" in result.error if result.error else False
+
+        await channel.close()
+
+
+async def test_channel_name_mismatch_raises() -> None:
+    channel = WebChannel(webhook_url="http://example.com/webhook")
+
+    message = ChannelMessage(channel_name="slack", content="Hello")
+
+    with pytest.raises(ChannelRejectedError, match="does not match adapter"):
+        await channel.send(message)
+
+
+async def test_implements_channel_provider() -> None:
+    channel = WebChannel(webhook_url="http://example.com/webhook")
+    assert isinstance(channel, ChannelProvider)
+    assert isinstance(channel, ChannelAdapterBase)
+    await channel.close()
+
+
+async def test_channel_name_is_web() -> None:
+    channel = WebChannel(webhook_url="http://example.com/webhook")
+    assert channel.name() == "web"
+    await channel.close()


### PR DESCRIPTION
P4-2: Channel adapter base + web channel (#65)

### What was implemented
- ChannelAdapterBase (ABC) implementing ChannelProvider with structured logging helper
- WebChannel — HTTP POST to configured webhook URL
- Error types: ChannelTransportError, ChannelRejectedError
- AppConfig.web_channel_webhook_url: str | None = None (env: WAYWARDEN_WEB_CHANNEL_WEBHOOK_URL)

### Files changed
- src/waywarden/adapters/channel/__init__.py — package exports
- src/waywarden/adapters/channel/base.py — ChannelAdapterBase ABC
- src/waywarden/adapters/channel/errors.py — error types
- src/waywarden/adapters/channel/web.py — WebChannel implementation
- src/waywarden/config/settings.py — added web_channel_webhook_url
- tests/adapters/channel/test_web.py — 8 unit tests with httpx mock
- tests/adapters/channel/test_no_repo_imports.py — static scan test

### Validation
- mypy --strict clean
- All 9 channel tests pass
- Pre-existing test failures confirmed not related to this change

### Branch
- issue-65-channel-adapter-base
- Commit: 10c12bf87cd07245524898f87ca8c0c39fef9206