### PR TITLE
P4-3: Orchestration service skeleton (#66)

### DIFF
--- a/docs/orchestration/milestone-catalog.md
+++ b/docs/orchestration/milestone-catalog.md
@@ -1,0 +1,49 @@
+# Orchestration Milestone Catalog
+
+Catalogue of every `run.progress` `phase` / `milestone` pair used by the
+orchestration service.  Every milestone value referenced by orchestration
+code **must** appear here.
+
+## Phases
+
+### intake
+
+| Milestone      | Description                                |
+| -------------- | ------------------------------------------ |
+| `received`     | Task received and parsed by the harness    |
+| `accepted`     | Task accepted for processing               |
+
+### plan
+
+| Milestone            | Description                                |
+| -------------------- | ------------------------------------------ |
+| `drafted`            | Initial plan drafted                       |
+| `approval_requested` | Plan submitted for approval gate           |
+| `ready`              | Plan approved and ready for execution      |
+
+### execute
+
+| Milestone          | Description                           |
+| ------------------ | ------------------------------------- |
+| `tool_invoked`     | A tool invocation starts              |
+| `artifact_emitted` | A tool or step produced an artifat    |
+| `waiting_approval` | Execution paused at an approval gate  |
+
+### review
+
+| Milestone            | Description                       |
+| -------------------- | --------------------------------- |
+| `findings_recorded`  | Review findings are durably saved |
+
+### handoff
+
+| Milestone         | Description                              |
+| ----------------- | ---------------------------------------- |
+| `envelope_emitted` | Delegation envelope registered for child |
+
+## Rules
+
+- `phase` and `milestone` values are case-sensitive.
+- Free-form strings are forbidden on `run.progress` events; callers
+  **must** use values declared in this catalog.
+- Adding a new milestone requires updating this catalog first.

--- a/src/waywarden/services/orchestration/__init__.py
+++ b/src/waywarden/services/orchestration/__init__.py
@@ -1,0 +1,19 @@
+"""Orchestration service package."""
+
+from __future__ import annotations
+
+from waywarden.services.orchestration.milestones import (
+    MILESTONE_CATALOG,
+    MILESTONES,
+    MilestoneDefinition,
+    ValidMilestone,
+    ValidPhase,
+)
+
+__all__ = [
+    "MILESTONE_CATALOG",
+    "MILESTONES",
+    "MilestoneDefinition",
+    "ValidPhase",
+    "ValidMilestone",
+]

--- a/src/waywarden/services/orchestration/milestones.py
+++ b/src/waywarden/services/orchestration/milestones.py
@@ -1,0 +1,91 @@
+"""Milestone catalog for orchestration phases.
+
+Every ``run.progress`` ``phase`` / ``milestone`` pair used by the
+orchestration service must be declared here.  Callers must use these
+constants — free-form strings on ``run.progress`` events are forbidden.
+
+Definition of record:
+``docs/orchestration/milestone-catalog.md``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+# Phase types — these are the five sub-phases of the orchestration run.
+ValidPhase = Literal["intake", "plan", "execute", "review", "handoff"]
+
+# Milestone tokens — indexed by phase for type safety.
+ValidMilestone = str  # literal values enforced at runtime against MILESTONE_CATALOG
+
+
+@dataclass(frozen=True, slots=True)
+class MilestoneDefinition:
+    """Immutable definition of a single milestone within a phase.
+
+    Parameters
+    ----------
+    phase:
+        The orchestration sub-phase this milestone belongs to.
+    milestone:
+        The stable milestone token (e.g. ``"received"``).
+    description:
+        Human-readable explanation for documentation surfaces.
+    """
+
+    phase: ValidPhase
+    milestone: str
+    description: str
+
+
+ALL_PHASES: tuple[ValidPhase, ...] = ("intake", "plan", "execute", "review", "handoff")
+
+MILESTONE_CATALOG: tuple[MilestoneDefinition, ...] = (
+    # intake
+    MilestoneDefinition("intake", "received", "Task received and parsed by the harness"),
+    MilestoneDefinition("intake", "accepted", "Task accepted for processing"),
+    # plan
+    MilestoneDefinition("plan", "drafted", "Initial plan drafted"),
+    MilestoneDefinition("plan", "approval_requested", "Plan submitted for approval gate"),
+    MilestoneDefinition("plan", "ready", "Plan approved and ready for execution"),
+    # execute
+    MilestoneDefinition("execute", "tool_invoked", "A tool invocation starts"),
+    MilestoneDefinition("execute", "artifact_emitted", "A tool or step produced an artifact"),
+    MilestoneDefinition(
+        "execute",
+        "waiting_approval",
+        "Execution paused at an approval gate",
+    ),
+    # review
+    MilestoneDefinition(
+        "review",
+        "findings_recorded",
+        "Review findings are durably saved",
+    ),
+    # handoff
+    MilestoneDefinition(
+        "handoff",
+        "envelope_emitted",
+        "Delegation envelope registered for child run",
+    ),
+)
+
+# Fast lookup for validation at runtime.
+_MILESTONE_SET: frozenset[tuple[str, str]] = frozenset(
+    (md.phase, md.milestone) for md in MILESTONE_CATALOG
+)
+
+
+def is_valid_milestone(phase: str, milestone: str) -> bool:
+    """Return ``True`` when *phase*/*milestone* is declared in the catalog."""
+    return (phase, milestone) in _MILESTONE_SET
+
+
+def get_milestones(phase: ValidPhase) -> tuple[str, ...]:
+    """Return the milestone tokens for a given phase."""
+    return tuple(md.milestone for md in MILESTONE_CATALOG if md.phase == phase)
+
+
+# Derived constants matching the issue's required milestone names.
+MILESTONES: dict[ValidPhase, tuple[str, ...]] = {p: get_milestones(p) for p in ALL_PHASES}

--- a/src/waywarden/services/orchestration/service.py
+++ b/src/waywarden/services/orchestration/service.py
@@ -1,0 +1,306 @@
+"""Orchestration service skeleton.
+
+Drives a run through the ``intake -> plan -> execute -> review -> handoff``
+sub-phases as a sequence of ``run.progress`` milestone events (RT-002).
+Top-level ``Run.state`` values stay canonical per RT-002; the
+orchestration service emits progress events alongside canonical state
+transitions.
+
+See ADR-0011 (adapter boundaries) and RT-002 (run event protocol).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+from waywarden.domain.ids import RunEventId
+from waywarden.domain.run import Run, RunState
+from waywarden.domain.run_event import Actor, Causation, RunEvent
+from waywarden.domain.token_usage import summary_artifact_ref
+from waywarden.services.orchestration.milestones import is_valid_milestone
+
+if TYPE_CHECKING:
+    from waywarden.domain.repositories import RunEventRepository, RunRepository
+    from waywarden.services.approval_engine import ApprovalEngine
+
+logger = getLogger(__name__)
+
+
+# Terminal events that suppress further run.progress emissions.
+_TERMINAL_EVENTS: frozenset[str] = frozenset(
+    ["run.completed", "run.failed", "run.cancelled"]
+)
+
+# 7 canonical RT-002 run states — no invented states.
+_VALID_RUN_STATES: frozenset[RunState] = frozenset(
+    ["created", "planning", "executing", "waiting_approval", "completed", "failed", "cancelled"]
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OrchestrationService:
+    """Drives a run through orchestration sub-phases.
+
+    The service owns the phase machine lifecycle.  It writes canonical
+    RT-002 lifecycle events (created, plan_ready, etc.) and emits
+    ``run.progress`` milestones in the strict catalog from
+    ``milestones.py``.
+
+    Parameters
+    ----------
+    runs:
+        Repository for ``Run`` persisted records.
+    events:
+        Append-only event log (RT-002).
+    approvals:
+        Approval engine for gating decisions.
+    """
+
+    runs: RunRepository = field(repr=False)
+    events: RunEventRepository = field(repr=False)
+    approvals: ApprovalEngine = field(repr=False)
+
+    # -- public API ----------------------------------------------------------
+
+    async def run(
+        self,
+        run: Run,
+    ) -> Run:
+        """Execute the full orchestration pipeline on *run*.
+
+        Drives the canonical sub-phases:
+        ``intake -> plan -> execute -> review -> handoff``.
+
+        Parameters
+        ----------
+        run:
+            The run to orchestrate.  Must be in ``created`` state.
+
+        Returns
+        -------
+        The updated ``Run`` with terminal state.
+        """
+        if run.state != "created":
+            raise ValueError(
+                f"run must be in 'created' state to start orchestration, "
+                f"got {run.state!r}"
+            )
+
+        # Validate state space — only the 7 RT-002 states are allowed.
+        assert run.state in _VALID_RUN_STATES, (
+            f"State {run.state!r} is not in the 7 RT-002 run states"
+        )
+
+        next_run = await self._do_intake(run)
+        next_run = await self._do_plan(next_run)
+        next_run = await self._do_execute(next_run)
+        next_run = await self._do_review(next_run)
+        next_run = await self._do_handoff(next_run)
+
+        return next_run
+
+    # -- sub-phase implementations -------------------------------------------
+
+    async def _do_intake(self, run: Run) -> Run:
+        """intake phase: received → accepted."""
+        now = datetime.now(UTC)
+
+        # Emit intake.received
+        await self._emit_progress(run, "intake", "received", now)
+
+        # Emit intake.accepted
+        await self._emit_progress(run, "intake", "accepted", now)
+
+        # Transition: created → planning
+        next_run = await self._update_state(run, "planning", now)
+        return next_run
+
+    async def _do_plan(self, run: Run) -> Run:
+        """plan phase: drafted → approval_requested → ready."""
+        now = datetime.now(UTC)
+
+        # Emit plan.drafted
+        await self._emit_progress(run, "plan", "drafted", now)
+
+        # Emit plan.approval_requested (stub — approval engine integration)
+        await self._emit_progress(run, "plan", "approval_requested", now)
+
+        # Emit plan.ready (stub — simplified; no real approval gate in skeleton)
+        await self._emit_progress(run, "plan", "ready", now)
+
+        next_run = await self._update_state(run, "planning", now)
+        return next_run
+
+    async def _do_execute(self, run: Run) -> Run:
+        """execute phase: tool_invoked → artifact_emitted → waiting_approval."""
+        now = datetime.now(UTC)
+
+        # Emit execute.tool_invoked
+        await self._emit_progress(run, "execute", "tool_invoked", now)
+
+        # Emit execute.artifact_emitted
+        await self._emit_progress(run, "execute", "artifact_emitted", now)
+
+        # Emit execute.waiting_approval
+        await self._emit_progress(run, "execute", "waiting_approval", now)
+
+        next_run = await self._update_state(run, "executing", now)
+        return next_run
+
+    async def _do_review(self, run: Run) -> Run:
+        """review phase: findings_recorded."""
+        now = datetime.now(UTC)
+
+        await self._emit_progress(run, "review", "findings_recorded", now)
+
+        next_run = await self._update_state(run, "planning", now)
+        return next_run
+
+    async def _do_handoff(self, run: Run) -> Run:
+        """handoff phase: envelope_emitted → then terminal."""
+        now = datetime.now(UTC)
+
+        # Emit handoff.envelope_emitted (stub — P4-8 delegation)
+        await self._emit_progress(run, "handoff", "envelope_emitted", now)
+
+        # Emit terminal usage-summary artifact before completed
+        await self._emit_usage_summary_artifact(run, now)
+
+        # Emit run.completed event
+        await self._emit_completed(run, now)
+
+        # Terminal: completed
+        next_run = await self._update_state(run, "completed", now)
+        return next_run
+
+    # -- helpers -------------------------------------------------------------
+
+    async def _emit_progress(
+        self,
+        run: Run,
+        phase: str,
+        milestone: str,
+        timestamp: datetime,
+    ) -> None:
+        """Emit a ``run.progress`` milestone event.
+
+        Validates that the phase/milestone pair is in the catalog before
+        persisting.
+        """
+        if not is_valid_milestone(phase, milestone):
+            raise ValueError(
+                f"progress event phase={phase!r}, milestone={milestone!r} "
+                f"is not in the milestone catalog"
+            )
+
+        # Check terminal guard: no progress after terminal events.
+        if self._is_terminal_run(run):
+            raise RuntimeError(
+                f"attempted to emit progress after run {run.id} reached "
+                f"terminal state {run.state!r}"
+            )
+
+        last_seq = await self.events.latest_seq(str(run.id))
+        event = RunEvent(
+            id=RunEventId(f"evt-{run.id}-{phase}-{milestone}"),
+            run_id=run.id,
+            seq=last_seq + 1,
+            type="run.progress",
+            payload={
+                "phase": phase,
+                "milestone": milestone,
+            },
+            timestamp=timestamp,
+            causation=Causation(
+                event_id=None,
+                action=f"{phase}.{milestone}",
+                request_id=None,
+            ),
+            actor=Actor(kind="system", id=None, display=None),
+        )
+
+        await self.events.append(event)
+        logger.debug(
+            "emitted run.progress(%s.%s) seq=%d", phase, milestone, event.seq
+        )
+
+    async def _emit_completed(
+        self, run: Run, timestamp: datetime
+    ) -> None:
+        """Emit the terminal ``run.completed`` event."""
+        last_seq = await self.events.latest_seq(str(run.id))
+        event = RunEvent(
+            id=RunEventId(f"evt-{run.id}-completed"),
+            run_id=run.id,
+            seq=last_seq + 1,
+            type="run.completed",
+            payload={
+                "outcome": "success",
+            },
+            timestamp=timestamp,
+            causation=Causation(
+                event_id=None,
+                action="terminal_completion",
+                request_id=None,
+            ),
+            actor=Actor(kind="system", id=None, display=None),
+        )
+        await self.events.append(event)
+
+    async def _emit_usage_summary_artifact(
+        self,
+        run: Run,
+        timestamp: datetime,
+    ) -> None:
+        """Emit the terminal ``run.artifact_created(kind=usage-summary)``."""
+        last_seq = await self.events.latest_seq(str(run.id))
+        artifact_ref = summary_artifact_ref(str(run.id))
+        event = RunEvent(
+            id=RunEventId(f"evt-{run.id}-usage-summary"),
+            run_id=run.id,
+            seq=last_seq + 1,
+            type="run.artifact_created",
+            payload={
+                "artifact_ref": artifact_ref,
+                "artifact_kind": "usage-summary",
+                "label": "usage-summary",
+            },
+            timestamp=timestamp,
+            causation=Causation(
+                event_id=None,
+                action="terminal_usage_summary",
+                request_id=None,
+            ),
+            actor=Actor(kind="system", id=None, display=None),
+        )
+        await self.events.append(event)
+
+    async def _update_state(
+        self,
+        run: Run,
+        new_state: RunState,
+        timestamp: datetime,
+    ) -> Run:
+        """Persist the run state transition."""
+        assert new_state in _VALID_RUN_STATES, (
+            f"State {new_state!r} is not in the 7 RT-002 run states"
+        )
+        updated = await self.runs.update_state(
+            run_id=str(run.id),
+            new_state=new_state,
+            terminal_seq=None,
+        )
+        # Hydrate full record (skeleton: returns as-is since we don't have
+        # a proper run repository implementation in tests).
+        return updated
+
+    def _is_terminal_run(self, run: Run) -> bool:
+        """Return True if the run is in a terminal state."""
+        return run.state in _VALID_RUN_STATES and run.state in {
+            "completed",
+            "failed",
+            "cancelled",
+        }

--- a/tests/services/orchestration/test_no_invented_events.py
+++ b/tests/services/orchestration/test_no_invented_events.py
@@ -1,0 +1,57 @@
+"""Static scan ensuring orchestration code emits only RT-002 catalog event types.
+
+RT-002 §Token usage accounting: Implementations must NOT append
+``run.usage`` or similar non-catalog event types.  This test enforces
+that constraint with a static grep across ``src/waywarden/``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Event types that must never be emitted.
+_FORBIDDEN_PATTERNS: frozenset[str] = frozenset(
+    [
+        "run\\.usage",
+        "run\\.state_changed",
+        "run\\.stage_",
+        "run\\.task_updated",
+    ]
+)
+
+_SRC_ROOT = Path(__file__).resolve().parent.parent.parent.parent / "waywarden"
+
+
+def _grep_for_forbidden_patterns() -> list[str]:
+    """Return lines matching any forbidden event type pattern."""
+    bad_lines: list[str] = []
+    for pattern in _FORBIDDEN_PATTERNS:
+        result = subprocess.run(
+            [
+                "rg",
+                "--type=py",
+                "--no-heading",
+                "--line-number",
+                pattern,
+                str(_SRC_ROOT),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:  # found matches
+            for line in result.stdout.splitlines():
+                if "test_no_invented_events" in line:
+                    continue
+                bad_lines.append(f"{pattern} → {line}")
+    return bad_lines
+
+
+def test_only_catalog_event_types_emitted() -> None:
+    """Ensure no forbidden event types appear in source code."""
+    bad_lines = _grep_for_forbidden_patterns()
+    if bad_lines:
+        header = "Orchestration code must only emit RT-002 catalog event types."
+        lines = [header]
+        lines.extend(f"- {v}" for v in bad_lines)
+        raise AssertionError("\n".join(lines))

--- a/tests/services/orchestration/test_no_stage_axis.py
+++ b/tests/services/orchestration/test_no_stage_axis.py
@@ -1,0 +1,18 @@
+"""Assert Run does not expose a stage or phase domain axis.
+
+RT-002 defines seven canonical run states — no additional axis like
+``stage`` or ``phase`` exists on the ``Run`` dataclass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+
+from waywarden.domain.run import Run
+
+
+def test_run_state_axis_is_rt002() -> None:
+    """Run must not have a ``stage`` or ``phase`` field."""
+    field_names = {f.name for f in fields(Run)}
+    assert "stage" not in field_names, "Run must not expose a 'stage' field"
+    assert "phase" not in field_names, "Run must not expose a 'phase' field"

--- a/tests/services/orchestration/test_run_lifecycle.py
+++ b/tests/services/orchestration/test_run_lifecycle.py
@@ -1,0 +1,236 @@
+"""Integration tests for the orchestration service.
+
+Uses fake repositories backed by in-memory structures to prove the
+full run lifecycle and milestone catalog compliance against Postgres-like
+persistence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from waywarden.domain.ids import RunId, TaskId
+from waywarden.domain.run import Run
+from waywarden.domain.run_event import RunEvent
+from waywarden.services.orchestration.milestones import MILESTONE_CATALOG
+from waywarden.services.orchestration.service import OrchestrationService
+
+# ---------------------------------------------------------------------------
+# Minimal fake repositories for integration testing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FakeRunRepository:
+    """In-memory Run repository."""
+
+    _runs: dict[str, Run] = field(default_factory=dict)
+
+    async def create(self, run: Run) -> Run:
+        self._runs[str(run.id)] = run
+        return run
+
+    async def get(self, run_id: str) -> Run | None:
+        return self._runs.get(run_id)
+
+    async def load_latest_state(self, run_id: str) -> Run | None:
+        return self._runs.get(run_id)
+
+    async def update_state(
+        self,
+        run_id: str,
+        new_state: str,
+        terminal_seq: int | None,
+    ) -> Run:
+        existing = self._runs.get(run_id)
+        if existing is None:
+            raise ValueError(f"run {run_id!r} not found")
+
+        updated = Run(
+            id=existing.id,
+            instance_id=existing.instance_id,
+            task_id=existing.task_id,
+            profile=existing.profile,
+            policy_preset=existing.policy_preset,
+            manifest_ref=existing.manifest_ref,
+            entrypoint=existing.entrypoint,
+            state=new_state,  # type: ignore[arg-type]
+            created_at=existing.created_at,
+            updated_at=datetime.now(UTC),
+            terminal_seq=terminal_seq,
+        )
+        self._runs[run_id] = updated
+        return updated
+
+
+@dataclass(frozen=True, slots=True)
+class FakeRunEventRepository:
+    """Append-only in-memory RunEvent repository."""
+
+    _events: dict[str, list[RunEvent]] = field(default_factory=dict)
+    _seq_counters: dict[str, int] = field(default_factory=dict)
+
+    async def append(self, event: RunEvent) -> RunEvent:
+        run_events = self._events.setdefault(str(event.run_id), [])
+        run_events.append(event)
+        self._seq_counters[str(event.run_id)] = event.seq
+        return event
+
+    async def list(
+        self,
+        run_id: str,
+        *,
+        since_seq: int = 0,
+        limit: int | None = None,
+    ) -> list[RunEvent]:
+        events = self._events.get(run_id, [])
+        result = [e for e in events if e.seq > since_seq]
+        if limit is not None:
+            result = result[:limit]
+        return result
+
+    async def latest_seq(self, run_id: str) -> int:
+        return self._seq_counters.get(run_id, 0)
+
+
+@dataclass(frozen=True, slots=True)
+class FakeApprovalEngine:
+    """Stub approval engine for orchestration integration tests."""
+
+    async def request(  # type: ignore[empty-body]
+        self,
+        run_id: str,
+        approval_kind: str,
+        summary: str,
+        **_: Any,
+    ) -> Any:
+        return None
+
+    async def resolve(self, approval_id: str, decision: Any) -> Any:  # type: ignore[empty-body]
+        return None
+
+
+def _make_run() -> Run:
+    from waywarden.domain.ids import InstanceId
+
+    now = datetime.now(UTC)
+    return Run(
+        id=RunId("run-001"),
+        instance_id=InstanceId("inst-001"),
+        task_id=TaskId("task-001"),
+        profile="ea",
+        policy_preset="ask",
+        manifest_ref="manifest://v1",
+        entrypoint="api",
+        state="created",
+        created_at=now,
+        updated_at=now,
+        terminal_seq=None,
+    )
+
+
+class TestFullHappyPathEmitsCanonicalSequence:
+    """Integration tests proving the full orchestration sequence."""
+
+    @pytest.mark.integration
+    async def test_full_happy_path_emits_canonical_sequence(self) -> None:
+        """The full happy path emits all milestone progress events plus the
+        terminal usage-summary artifact, all in ascending seq order."""
+        runs_repo = FakeRunRepository()
+        events_repo = FakeRunEventRepository()
+        approvals = FakeApprovalEngine()
+
+        service = OrchestrationService(
+            runs=runs_repo,
+            events=events_repo,
+            approvals=approvals,
+        )
+
+        run = await runs_repo.create(_make_run())
+        final_run = await service.run(run)
+
+        assert final_run.state == "completed"
+
+        # Verify all events are in ascending seq order.
+        all_events = await events_repo.list("run-001")
+        seqs = [e.seq for e in all_events]
+        assert seqs == sorted(seqs), "Events must be in ascending seq order"
+        assert seqs == list(range(1, len(seqs) + 1)), "No gaps in seq"
+
+        # Verify milestones were emitted for each phase
+        phases_seen: set[str] = set()
+        for event in all_events:
+            if event.type == "run.progress":
+                phases_seen.add(event.payload["phase"])
+
+        assert phases_seen == {"intake", "plan", "execute", "review", "handoff"}
+
+    @pytest.mark.integration
+    async def test_progress_events_use_catalog_values(self) -> None:
+        """Every run.progress emitted uses phase/milestone pairs from the
+        milestone catalog."""
+        runs_repo = FakeRunRepository()
+        events_repo = FakeRunEventRepository()
+        approvals = FakeApprovalEngine()
+
+        service = OrchestrationService(
+            runs=runs_repo,
+            events=events_repo,
+            approvals=approvals,
+        )
+
+        run = await runs_repo.create(_make_run())
+        await service.run(run)
+
+        all_events = await events_repo.list("run-001")
+        for event in all_events:
+            if event.type == "run.progress":
+                phase = event.payload["phase"]
+                milestone = event.payload["milestone"]
+                valid = any(
+                    md.phase == phase and md.milestone == milestone
+                    for md in MILESTONE_CATALOG
+                )
+                assert valid, (
+                    f"progress event phase={phase!r}, milestone={milestone!r} "
+                    f"is not in the milestone catalog"
+                )
+
+    @pytest.mark.integration
+    async def test_terminal_usage_summary_artifact_emitted(self) -> None:
+        """Before run.completed, a usage-summary artifact is registered."""
+        runs_repo = FakeRunRepository()
+        events_repo = FakeRunEventRepository()
+        approvals = FakeApprovalEngine()
+
+        service = OrchestrationService(
+            runs=runs_repo,
+            events=events_repo,
+            approvals=approvals,
+        )
+
+        run = await runs_repo.create(_make_run())
+        await service.run(run)
+
+        all_events = await events_repo.list("run-001")
+        usage_artifact_seq: int | None = None
+        completed_seq: int | None = None
+        for event in all_events:
+            if event.type == "run.artifact_created" and event.payload.get(
+                "artifact_kind"
+            ) == "usage-summary":
+                    usage_artifact_seq = event.seq
+            if event.type == "run.completed":
+                completed_seq = event.seq
+
+        assert usage_artifact_seq is not None, (
+            "usage-summary artifact must be emitted before run.completed"
+        )
+        assert completed_seq is not None, "run.completed must be emitted"
+        assert usage_artifact_seq < completed_seq, (
+            "usage-summary artifact must be emitted before run.completed"
+        )


### PR DESCRIPTION
P4-3: Orchestration service skeleton (#66)

### What was implemented
- OrchestrationService(runs, events, approvals) driving intake -> plan -> execute -> review -> handoff
- Milestone catalog in src/waywarden/services/orchestration/milestones.py
- Milestone catalog doc in docs/orchestration/milestone-catalog.md
- Terminal run.completed event and usage-summary artifact emit
- Static scan test forbidding invented event types
- Run model has no stage/phase field (verified by test)

### Files changed
- docs/orchestration/milestone-catalog.md — declared milestone pairs
- src/waywarden/services/orchestration/__init__.py — package exports
- src/waywarden/services/orchestration/milestones.py — MilestoneDefinition catalog
- src/waywarden/services/orchestration/service.py — OrchestrationService
- tests/services/orchestration/test_run_lifecycle.py — 3 integration tests
- tests/services/orchestration/test_no_invented_events.py — static grep
- tests/services/orchestration/test_no_stage_axis.py — Run field audit

### Validation
- mypy --strict clean
- All 5 orchestration tests pass
- Pre-existing test failures confirmed not related

### Branch
- issue-66-orchestration-service-skeleton