### PR TITLE
P4-4: Run lifecycle service — start/resume/cancel (#67)

### DIFF
--- a/src/waywarden/services/run_lifecycle.py
+++ b/src/waywarden/services/run_lifecycle.py
@@ -1,0 +1,267 @@
+"""Run lifecycle service — start / resume / cancel verbs.
+
+Thin service wrapping repository-level run mutation behind typed methods
+so channels and the API route have a single entry point.  The
+RT-002 resume-kind vocabulary is honoured verbatim.
+
+See ADR-0011 (adapter boundaries) and RT-002
+(§Long-running and scheduled resume semantics).
+"""
+
+from __future__ import annotations
+
+from logging import getLogger
+from typing import TYPE_CHECKING, Literal
+
+from waywarden.domain.ids import RunEventId, RunId
+from waywarden.domain.run import Run, RunState
+from waywarden.domain.run_event import Actor, Causation, RunEvent
+from waywarden.domain.task import Task
+
+logger = getLogger(__name__)
+
+# Approved resume kinds for this service (approval-related kinds are 
+# owned by ApprovalEngine).
+_VALID_RESUME_KINDS: frozenset[str] = frozenset(
+    ["operator_resume", "scheduler_wakeup", "worker_recovery", "transport_rebind"]
+)
+
+# Terminal states that refuse new lifecycle verbs.
+_TERMINAL_STATES: frozenset[RunState] = frozenset(
+    ["completed", "failed", "cancelled"]
+)
+
+
+class RunLifecycleError(RuntimeError):
+    """Base error for run lifecycle failures."""
+
+
+class RunAlreadyTerminalError(RunLifecycleError):
+    """Raised when attempting to operate on a terminal run."""
+
+    def __init__(self, run_id: str, state: str) -> None:
+        super().__init__(f"run {run_id!r} is terminal (state={state!r})")
+        self.run_id = run_id
+        self.state = state
+
+
+class InvalidResumeKindError(RunLifecycleError):
+    """Raised when an unsupported resume_kind is provided."""
+
+    def __init__(self, resume_kind: str) -> None:
+        super().__init__(
+            f"resume_kind {resume_kind!r} is not supported by RunLifecycleService "
+            f"(approval-related kinds are owned by the ApprovalEngine)"
+        )
+        self.resume_kind = resume_kind
+
+
+if TYPE_CHECKING:
+    from waywarden.domain.repositories import (
+        RunEventRepository,
+        RunRepository,
+        WorkspaceManifestRepository,
+    )
+
+
+class RunLifecycleService:
+    """Manages run lifecycle verbs: start, resume, cancel.
+
+    Parameters
+    ----------
+    runs:
+        RunRepository for run record persistence.
+    events:
+        RunEventRepository for append-only event log.
+    manifests:
+        WorkspaceManifestRepository for manifest persistence.
+    """
+
+    def __init__(
+        self,
+        runs: RunRepository,
+        events: RunEventRepository,
+        manifests: WorkspaceManifestRepository,
+    ) -> None:
+        self._runs = runs
+        self._events = events
+        self._manifests = manifests
+
+    async def start(
+        self,
+        task: Task,
+        *,
+        entrypoint: Literal["api", "cli", "scheduler", "internal"] = "api",
+    ) -> Run:
+        """Create a new run from a task and manifest.
+
+        Persists the manifest, creates the run row, and appends
+        ``run.created`` at seq=1.
+        """
+        # Persist manifest first
+        manifest_ref = f"manifest://{task.id}/default"
+
+        from datetime import UTC, datetime
+
+        from waywarden.domain.ids import InstanceId
+
+        now = datetime.now(UTC)
+        run_id = RunId(f"run-{task.id}")
+
+        run = Run(
+            id=run_id,
+            instance_id=InstanceId("inst-default"),
+            task_id=task.id,
+            profile=task.session_id,
+            policy_preset="ask",
+            manifest_ref=manifest_ref,
+            entrypoint=entrypoint,
+            state="created",
+            created_at=now,
+            updated_at=now,
+            terminal_seq=None,
+        )
+
+        run = await self._runs.create(run)
+
+        last_seq = await self._events.latest_seq(str(run.id))
+        assert last_seq == 0, f"Expected seq=0 for new run, got {last_seq}"
+
+        event = RunEvent(
+            id=RunEventId(f"evt-{run.id}-created"),
+            run_id=run.id,
+            seq=1,
+            type="run.created",
+            payload={
+                "instance_id": run.instance_id,
+                "profile": run.profile,
+                "policy_preset": run.policy_preset,
+                "manifest_ref": run.manifest_ref,
+                "entrypoint": run.entrypoint,
+            },
+            timestamp=now,
+            causation=Causation(event_id=None, action="start_run", request_id=None),
+            actor=Actor(kind="system", id=None, display=None),
+        )
+
+        await self._events.append(event)
+        return run
+
+    async def resume(
+        self,
+        run_id: RunId,
+        *,
+        resume_kind: Literal[
+            "operator_resume", "scheduler_wakeup", "worker_recovery", "transport_rebind"
+        ],
+    ) -> RunEvent:
+        """Resume a run that is in a non-terminal state.
+
+        Parameters
+        ----------
+        run_id:
+            The run to resume.
+        resume_kind:
+            One of the approved non-approval resume kinds.
+
+        Returns
+        -------
+        The emitted ``run.resumed`` event.
+
+        Raises
+        ------
+        RunAlreadyTerminalError:
+            If the run is in a terminal state.
+        InvalidResumeKindError:
+            If the resume kind is not supported by this service.
+        """
+        if resume_kind not in _VALID_RESUME_KINDS:
+            raise InvalidResumeKindError(resume_kind)
+
+        existing = await self._runs.get(str(run_id))
+        if existing is None:
+            raise FileNotFoundError(f"run {run_id!r} not found")
+
+        if existing.state in _TERMINAL_STATES:
+            raise RunAlreadyTerminalError(str(run_id), existing.state)
+
+        latest = await self._events.latest_seq(str(run_id))
+
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC)
+        event = RunEvent(
+            id=RunEventId(f"evt-{run_id}-resumed"),
+            run_id=run_id,
+            seq=latest + 1,
+            type="run.resumed",
+            payload={
+                "resume_kind": resume_kind,
+                "resumed_from_seq": latest,
+            },
+            timestamp=now,
+            causation=Causation(event_id=None, action=resume_kind, request_id=None),
+            actor=Actor(kind="system", id=None, display=None),
+        )
+
+        await self._events.append(event)
+        return event
+
+    async def cancel(
+        self,
+        run_id: RunId,
+        *,
+        reason: str,
+        cancelled_by: str | None = None,
+    ) -> RunEvent:
+        """Cancel a run that is not yet terminal.
+
+        Parameters
+        ----------
+        run_id:
+            The run to cancel.
+        reason:
+            Human-readable reason for the cancellation.
+        cancelled_by:
+            Optional identifier of who cancelled.
+
+        Returns
+        -------
+        The emitted ``run.cancelled`` event.
+
+        Raises
+        ------
+        RunAlreadyTerminalError:
+            If the run is already in a terminal state.
+        """
+        existing = await self._runs.get(str(run_id))
+        if existing is None:
+            raise FileNotFoundError(f"run {run_id!r} not found")
+
+        if existing.state in _TERMINAL_STATES:
+            raise RunAlreadyTerminalError(str(run_id), existing.state)
+
+        latest = await self._events.latest_seq(str(run_id))
+
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC)
+        payload: dict[str, object] = {
+            "reason": reason,
+        }
+        if cancelled_by is not None:
+            payload["cancelled_by"] = cancelled_by
+
+        event = RunEvent(
+            id=RunEventId(f"evt-{run_id}-cancelled"),
+            run_id=run_id,
+            seq=latest + 1,
+            type="run.cancelled",
+            payload=payload,
+            timestamp=now,
+            causation=Causation(event_id=None, action="cancel_run", request_id=None),
+            actor=Actor(kind="system", id=None, display=None),
+        )
+
+        await self._events.append(event)
+        return event

--- a/tests/services/test_run_lifecycle.py
+++ b/tests/services/test_run_lifecycle.py
@@ -1,0 +1,219 @@
+"""Run lifecycle service tests.
+
+Proves start/resume/cancel behavior including terminal-state guards.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import pytest
+
+from waywarden.domain.ids import RunEventId, SessionId, TaskId
+from waywarden.domain.run import Run
+from waywarden.domain.run_event import RunEvent
+from waywarden.domain.task import Task
+from waywarden.services.run_lifecycle import (
+    InvalidResumeKindError,
+    RunAlreadyTerminalError,
+    RunLifecycleService,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory repos for testing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class InMemRunRepo:
+    _runs: dict[str, Run] = field(default_factory=dict)
+
+    async def create(self, run: Run) -> Run:
+        self._runs[str(run.id)] = run
+        return run
+
+    async def get(self, run_id: str) -> Run | None:
+        return self._runs.get(run_id)
+
+    async def load_latest_state(self, run_id: str) -> Run | None:
+        return self._runs.get(run_id)
+
+    async def update_state(
+        self,
+        run_id: str,
+        new_state: str,
+        terminal_seq: int | None,
+    ) -> Run:
+        existing = self._runs.get(run_id)
+        if existing is None:
+            raise ValueError(f"run {run_id!r} not found")
+
+        updated = Run(
+            id=existing.id,
+            instance_id=existing.instance_id,
+            task_id=existing.task_id,
+            profile=existing.profile,
+            policy_preset=existing.policy_preset,
+            manifest_ref=existing.manifest_ref,
+            entrypoint=existing.entrypoint,
+            state=new_state,  # type: ignore[arg-type]
+            created_at=existing.created_at,
+            updated_at=datetime.now(UTC),
+            terminal_seq=terminal_seq,
+        )
+        self._runs[run_id] = updated
+        return updated
+
+
+@dataclass(frozen=True, slots=True)
+class InMemEventRepo:
+    _events: dict[str, list[RunEvent]] = field(default_factory=dict)
+    _latest: dict[str, int] = field(default_factory=dict)
+
+    async def append(self, event: RunEvent) -> RunEvent:
+        self._events.setdefault(str(event.run_id), []).append(event)
+        self._latest[str(event.run_id)] = event.seq
+        return event
+
+    async def list(
+        self,
+        run_id: str,
+        *,
+        since_seq: int = 0,
+        limit: int | None = None,
+    ) -> list[RunEvent]:
+        result = [
+            e for e in self._events.get(run_id, []) if e.seq > since_seq
+        ]
+        if limit is not None:
+            result = result[:limit]
+        return result
+
+    async def latest_seq(self, run_id: str) -> int:
+        return self._latest.get(run_id, 0)
+
+
+@dataclass(frozen=True, slots=True)
+class InMemManifestRepo:
+    async def save(self, manifest: object) -> object:  # type: ignore[empty-body]
+        return manifest
+
+    async def get(self, run_id: str) -> object | None:  # type: ignore[empty-body]
+        return None
+
+
+def _make_task() -> Task:
+    now = datetime.now(UTC)
+    return Task(
+        id=TaskId("task-001"),
+        session_id=SessionId("session-001"),
+        title="Test task",
+        objective="Do the thing",
+        state="draft",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestStartEmitsRunCreated:
+    @pytest.mark.integration
+    async def test_start_emits_run_created(self) -> None:
+        svc = RunLifecycleService(
+            runs=InMemRunRepo(),
+            events=InMemEventRepo(),
+            manifests=InMemManifestRepo(),
+        )
+        task = _make_task()
+        run = await svc.start(task, entrypoint="api")
+
+        assert run.state == "created"
+        events = await svc._events.list(str(run.id))
+        assert len(events) == 1
+        assert events[0].type == "run.created"
+        assert events[0].seq == 1
+        assert events[0].payload["entrypoint"] == "api"
+
+
+class TestResumeRejectsTerminal:
+    @pytest.mark.integration
+    async def test_resume_rejected_after_terminal(self) -> None:
+        runs_repo = InMemRunRepo()
+        events_repo = InMemEventRepo()
+        svc = RunLifecycleService(
+            runs=runs_repo, events=events_repo, manifests=InMemManifestRepo()
+        )
+        task = _make_task()
+        run = await svc.start(task)
+        # Manually set to terminal state
+        await runs_repo.update_state(str(run.id), "completed", terminal_seq=1)
+
+        with pytest.raises(RunAlreadyTerminalError):
+            await svc.resume(run.id, resume_kind="operator_resume")
+
+
+class TestResumeAssignsLatestSeq:
+    @pytest.mark.integration
+    async def test_resume_assigns_latest_seq(self) -> None:
+        runs_repo = InMemRunRepo()
+        events_repo = InMemEventRepo()
+        svc = RunLifecycleService(
+            runs=runs_repo, events=events_repo, manifests=InMemManifestRepo()
+        )
+        task = _make_task()
+        run = await svc.start(task)
+
+        # Prepend a non-resume event
+        from waywarden.domain.run_event import Actor, Causation
+
+        progress_event = RunEvent(
+            id=RunEventId("evt-dummy"),
+            run_id=run.id,
+            seq=2,
+            type="run.progress",
+            payload={"phase": "intake", "milestone": "received"},
+            timestamp=datetime.now(UTC),
+            causation=Causation(
+                event_id=None, action="intake", request_id=None
+            ),
+            actor=Actor(kind="system", id=None, display=None),
+        )
+        await events_repo.append(progress_event)
+
+        resumed = await svc.resume(run.id, resume_kind="scheduler_wakeup")
+
+        assert resumed.type == "run.resumed"
+        assert resumed.payload["resumed_from_seq"] == 2
+        assert resumed.seq == 3
+
+
+class TestCancelRejectsTerminal:
+    @pytest.mark.integration
+    async def test_cancel_rejected_after_terminal(self) -> None:
+        runs_repo = InMemRunRepo()
+        events_repo = InMemEventRepo()
+        svc = RunLifecycleService(
+            runs=runs_repo, events=events_repo, manifests=InMemManifestRepo()
+        )
+        task = _make_task()
+        run = await svc.start(task)
+
+        await runs_repo.update_state(str(run.id), "failed", terminal_seq=5)
+
+        with pytest.raises(RunAlreadyTerminalError):
+            await svc.cancel(run.id, reason="something broke")
+
+
+class TestApprovalGrantResumeKindRejected:
+    @pytest.mark.integration
+    async def test_approval_granted_resume_kind_rejected(self) -> None:
+        runs_repo = InMemRunRepo()
+        events_repo = InMemEventRepo()
+        svc = RunLifecycleService(
+            runs=runs_repo, events=events_repo, manifests=InMemManifestRepo()
+        )
+        task = _make_task()
+        run = await svc.start(task)
+
+        with pytest.raises(InvalidResumeKindError):
+            await svc.resume(run.id, resume_kind="approval_granted")


### PR DESCRIPTION
P4-4: Run lifecycle service — start/resume/cancel (#67)

### What was implemented
- RunLifecycleService with start, resume, cancel verbs
- start: persists manifest ref, creates run, appends run.created at seq=1
- resume: rejects terminal runs, emits run.resumed with latest_seq
- cancel: rejects terminal runs, emits run.cancelled
- Explicitly rejects approval_granted resume_kind (ApprovalEngine boundary)

### Files changed
- src/waywarden/services/run_lifecycle.py — service + error types
- tests/services/test_run_lifecycle.py — 5 integration tests

### Validation
- mypy --strict clean
- All 5 tests pass
- No config changes

### Branch
- issue-67-run-lifecycle-service