### PR TITLE
P5-1: Shared-asset metadata schema (#81)

### DIFF
--- a/assets/routines/ea-briefing/asset.yaml
+++ b/assets/routines/ea-briefing/asset.yaml
@@ -1,0 +1,12 @@
+id: ea-briefing
+kind: routine
+version: 1.0.0
+description: Produces a dated briefing artifact for the EA profile.
+tags:
+  - ea
+  - briefing
+required_providers:
+  - model
+profile_filter:
+  - op: include
+    tag: ea

--- a/src/waywarden/assets/__init__.py
+++ b/src/waywarden/assets/__init__.py
@@ -1,0 +1,21 @@
+"""Shared-asset domain models and metadata schema.
+
+Every asset under ``assets/<kind>/<id>/`` declares a typed metadata
+record through the ``AssetMetadata`` model (and kind-specific
+sub-classes).  This is the foundation for the asset loader and
+profile-filtering engine (P5-2 #82).
+"""
+
+from waywarden.assets.schema import (
+    KNOWN_ASSET_KINDS,
+    AssetKind,
+    AssetMetadata,
+    AssetValidationError,
+)
+
+__all__ = [
+    "AssetKind",
+    "AssetMetadata",
+    "AssetValidationError",
+    "KNOWN_ASSET_KINDS",
+]

--- a/src/waywarden/assets/schema.py
+++ b/src/waywarden/assets/schema.py
@@ -1,0 +1,401 @@
+"""Canonical metadata schema for shared assets.
+
+Every shared asset under ``assets/<kind>/<id>/`` carries a metadata
+record described by ``AssetMetadata`` (Pydantic v2).  Kind-specific
+sub-classes attach kind-level fields on top of the common base.
+
+This schema is the single authority for asset identification, version
+coercion, and profile-filter hints.  Loaders that read ``asset.yaml``
+must validate through these models and raise on any schema violation —
+silent coercion is explicitly forbidden.
+
+Canonical references:
+    - ADR 0002 (core + profile packs)
+    - ADR 0004 (extension contract)
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+# ---------------------------------------------------------------------------
+# Asset kind enumeration
+# ---------------------------------------------------------------------------
+
+AssetKind = Literal[
+    "routine",
+    "widget",
+    "command",
+    "prompt",
+    "tool",
+    "skill",
+    "agent",
+    "team",
+    "pipeline",
+    "policy",
+    "theme",
+    "context_provider",
+    "profile_overlay",
+]
+
+KNOWN_ASSET_KINDS: frozenset[AssetKind] = frozenset(
+    [
+        "routine",
+        "widget",
+        "command",
+        "prompt",
+        "tool",
+        "skill",
+        "agent",
+        "team",
+        "pipeline",
+        "policy",
+        "theme",
+        "context_provider",
+        "profile_overlay",
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# Auxiliary types
+# ---------------------------------------------------------------------------
+
+_PROFILE_FILTER_OP = Literal["include", "exclude"]
+
+# Semver regex pattern for version coercion.
+SEMVER_RE = (
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+
+
+class AssetValidationError(ValueError):
+    """Raised when asset metadata fails validation."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:
+        lines = ["Asset validation failed:"]
+        lines.extend(f"- {error}" for error in self.errors)
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Core metadata model
+# ---------------------------------------------------------------------------
+
+
+class AssetMetadata(BaseModel, frozen=True, extra="forbid"):
+    """Common metadata shared by every asset kind.
+
+    Required fields:
+        - ``id``: unique asset identifier (slug-like).
+        - ``kind``: one of the known ``AssetKind`` values.
+        - ``version``: semver string, coerced to ``X.Y.Z`` form.
+        - ``description``: human-readable description.
+        - ``tags``: optional label set for profile-filter hints.
+        - ``required_providers``: optional list of provider names this
+          asset needs to function.
+        - ``profile_filter``: optional profile-filter hints that gate
+          which profiles receive this asset.
+    """
+
+    id: str = Field(
+        min_length=1,
+        max_length=128,
+        pattern=r"^[a-z][a-z0-9_-]*$",
+    )
+    kind: AssetKind
+    version: str = Field(
+        min_length=5,
+        max_length=64,
+    )
+    description: str = Field(
+        min_length=1,
+        max_length=4096,
+    )
+    tags: tuple[str, ...] = ()
+    required_providers: tuple[str, ...] = ()
+    profile_filter: tuple[dict[str, Any], ...] = ()
+
+    @field_validator("id", mode="before")
+    @classmethod
+    def _normalize_id(cls, value: object) -> str:
+        if not isinstance(value, str):
+            raise TypeError("id must be a string")
+        normalized = value.strip().lower()
+        if not normalized:
+            raise ValueError("id must not be blank")
+        return normalized
+
+    @field_validator("kind", mode="before")
+    @classmethod
+    def _normalize_kind(cls, value: object) -> str:
+        if not isinstance(value, str):
+            raise TypeError("kind must be a string")
+        normalized = value.strip().lower()
+        if normalized not in KNOWN_ASSET_KINDS:
+            raise ValueError(f"kind must be one of {sorted(KNOWN_ASSET_KINDS)}, got {value!r}")
+        return normalized
+
+    @field_validator("version", mode="before")
+    @classmethod
+    def _coerce_version(cls, value: object) -> str:
+        """Coerce version values to strict ``X.Y.Z`` semver form.
+
+        Accepts numeric versions like ``1`` or ``1.2``, and normalises
+        them to ``1.0.0`` / ``1.2.0``.  Full semver strings pass
+        through unchanged (modulo stripping).
+        """
+        if not isinstance(value, str):
+            raise TypeError("version must be a string")
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("version must not be blank")
+        parts = normalized.split(".")
+        if all(p.isdigit() for p in parts) and len(parts) <= 3:
+            padded = parts + ["0"] * (3 - len(parts))
+            return ".".join(padded)
+        return normalized
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def _normalize_tags(cls, value: object) -> tuple[str, ...]:
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, (list, tuple)):
+            raise TypeError("tags must be a string or sequence of strings")
+        result: list[str] = []
+        seen: set[str] = set()
+        for idx, item in enumerate(value):
+            if not isinstance(item, str):
+                raise TypeError(f"tags[{idx}] must be a string")
+            trimmed = item.strip()
+            if not trimmed:
+                continue
+            if trimmed not in seen:
+                seen.add(trimmed)
+                result.append(trimmed)
+        return tuple(result)
+
+    @field_validator("required_providers", mode="before")
+    @classmethod
+    def _normalize_required_providers(cls, value: object) -> tuple[str, ...]:
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, (list, tuple)):
+            raise TypeError("required_providers must be a string or sequence of strings")
+        result: list[str] = []
+        for idx, item in enumerate(value):
+            if not isinstance(item, str):
+                raise TypeError(f"required_providers[{idx}] must be a string")
+            trimmed = item.strip().lower()
+            if not trimmed:
+                continue
+            result.append(trimmed)
+        return tuple(dict.fromkeys(result))
+
+    @field_validator("profile_filter", mode="before")
+    @classmethod
+    def _normalize_profile_filter(cls, value: object) -> tuple[dict[str, Any], ...]:
+        if not isinstance(value, (list, tuple)):
+            if value is None:
+                return ()
+            raise TypeError("profile_filter must be a sequence or null")
+        result: list[dict[str, Any]] = []
+        for idx, item in enumerate(value):
+            if not isinstance(item, dict):
+                raise TypeError(f"profile_filter[{idx}] must be a mapping")
+            for key in item:
+                if not isinstance(key, str):
+                    raise TypeError(f"profile_filter[{idx}] key must be a string")
+            result.append(dict(item))
+        return tuple(result)
+
+    @model_validator(mode="after")
+    def _validate_profile_filter_ops(self) -> AssetMetadata:
+        """Ensure profile_filter entries carry an ``op`` field."""
+        valid_ops: frozenset[str] = frozenset({"include", "exclude"})
+        for idx, entry in enumerate(self.profile_filter):
+            if "op" not in entry:
+                raise ValueError(
+                    f"profile_filter[{idx}] missing required 'op' field "
+                    f"(one of {sorted(valid_ops)})"
+                )
+            if entry["op"] not in valid_ops:
+                raise ValueError(
+                    f"profile_filter[{idx}].op must be one of "
+                    f"{sorted(valid_ops)}, got {entry['op']!r}"
+                )
+        return self
+
+    def to_json_schema(self) -> dict[str, Any]:
+        """Return a JSON Schema (Draft 2020-12) representation."""
+        return self.model_json_schema(
+            by_alias=True,
+            ref_template="#/definitions/{model}",
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a serialisable dict representation."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AssetMetadata:
+        """Validate and construct from a plain dict (for YAML loading).
+
+        Raises ``AssetValidationError`` when any field fails validation.
+        """
+        errors: list[str] = []
+        try:
+            return cls(**data)
+        except Exception as exc:
+            if hasattr(exc, "errors"):
+                for err in exc.errors():
+                    field = ".".join(str(part) for part in err.get("loc", []))
+                    msg = err.get("msg", str(exc))
+                    errors.append(f"{field}: {msg}")
+            else:
+                errors.append(str(exc))
+            raise AssetValidationError(errors) from exc
+
+
+# ---------------------------------------------------------------------------
+# Kind-specific metadata (extensibility)
+# ---------------------------------------------------------------------------
+
+
+class RoutineMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``routine`` kind.
+
+    Additional fields capture the routine's orchestration contract.
+    """
+
+    kind: Literal["routine"] = "routine"
+    milestones: tuple[str, ...] = ()
+    emits_events: tuple[str, ...] = ()
+
+
+class WidgetMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``widget`` kind."""
+
+    kind: Literal["widget"] = "widget"
+    ui_surface: str = ""
+    component_id: str = ""
+
+
+class CommandMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``command`` kind."""
+
+    kind: Literal["command"] = "command"
+    trigger: str = ""
+    aliases: tuple[str, ...] = ()
+
+
+class PromptMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``prompt`` kind."""
+
+    kind: Literal["prompt"] = "prompt"
+    template_format: Literal["jinja2", "mustache", "plain"] = "plain"
+    system_message: str = ""
+
+
+class ToolMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``tool`` kind."""
+
+    kind: Literal["tool"] = "tool"
+    function_name: str = ""
+    parameters_schema: dict[str, Any] = {}
+
+
+class SkillMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``skill`` kind."""
+
+    kind: Literal["skill"] = "skill"
+    trigger_patterns: tuple[str, ...] = ()
+
+
+class AgentMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``agent`` kind."""
+
+    kind: Literal["agent"] = "agent"
+    role: str = ""
+    max_tools_per_step: int = Field(ge=1)
+
+
+class TeamMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``team`` kind."""
+
+    kind: Literal["team"] = "team"
+    members: tuple[str, ...] = ()
+    coordinator: str = ""
+
+
+class PipelineMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``pipeline`` kind."""
+
+    kind: Literal["pipeline"] = "pipeline"
+    stages: tuple[str, ...] = ()
+    timeout_seconds: int = 0
+
+
+class PolicyMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``policy`` kind."""
+
+    kind: Literal["policy"] = "policy"
+    enforce_mode: Literal["allow", "block", "audit"] = "block"
+    preset: str = ""
+
+
+class ThemeMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``theme`` kind."""
+
+    kind: Literal["theme"] = "theme"
+    palette: tuple[str, ...] = ()
+    font_family: str = ""
+
+
+class ContextProviderMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``context_provider`` kind."""
+
+    kind: Literal["context_provider"] = "context_provider"
+    inject_keys: tuple[str, ...] = ()
+
+
+class ProfileOverlayMetadata(AssetMetadata, frozen=True):
+    """Asset metadata for ``profile_overlay`` kind."""
+
+    kind: Literal["profile_overlay"] = "profile_overlay"
+    target_profiles: tuple[str, ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# Cross-asset validation helpers
+# ---------------------------------------------------------------------------
+
+
+def validate_unique_ids(
+    assets: list[AssetMetadata],
+) -> list[str]:
+    """Return duplicate-id errors when the same ``id`` appears across
+    multiple assets (even across different kinds).
+
+    This enforces the "declare once, reference by id" contract from
+    ADR 0002 and ADR 0004.
+    """
+    seen: dict[str, list[AssetMetadata]] = {}
+    for asset in assets:
+        seen.setdefault(asset.id, []).append(asset)
+
+    errors: list[str] = []
+    for aid, entries in sorted(seen.items()):
+        if len(entries) > 1:
+            kinds = sorted(set(e.kind for e in entries))
+            errors.append(f"asset id {aid!r} is declared in {len(entries)} assets (kinds: {kinds})")
+    return errors

--- a/tests/unit/test_asset_schema.py
+++ b/tests/unit/test_asset_schema.py
@@ -1,0 +1,409 @@
+"""Tests for the shared-asset metadata schema (P5-1 #81)."""
+
+import pytest
+
+from waywarden.assets.schema import (
+    KNOWN_ASSET_KINDS,
+    AgentMetadata,
+    AssetMetadata,
+    AssetValidationError,
+    CommandMetadata,
+    ContextProviderMetadata,
+    PipelineMetadata,
+    PolicyMetadata,
+    ProfileOverlayMetadata,
+    PromptMetadata,
+    RoutineMetadata,
+    SkillMetadata,
+    TeamMetadata,
+    ThemeMetadata,
+    ToolMetadata,
+    WidgetMetadata,
+    validate_unique_ids,
+)
+
+# -----------------------------------------------------------------------
+# AssetMetadata — required fields
+# -----------------------------------------------------------------------
+
+
+def test_required_fields_are_set() -> None:
+    """AssetMetadata can be constructed with only required fields."""
+    meta = AssetMetadata(
+        id="test-asset",
+        kind="prompt",
+        version="1.0.0",
+        description="A test asset",
+    )
+    assert meta.id == "test-asset"
+    assert meta.kind == "prompt"
+    assert meta.version == "1.0.0"
+    assert meta.description == "A test asset"
+    assert meta.tags == ()
+    assert meta.required_providers == ()
+    assert meta.profile_filter == ()
+
+
+def test_description_must_not_be_blank() -> None:
+    with pytest.raises(AssetValidationError):
+        AssetMetadata.from_dict(
+            {
+                "id": "x",
+                "kind": "prompt",
+                "version": "1.0.0",
+                "description": "",
+            }
+        )
+
+
+# -----------------------------------------------------------------------
+# Version coercion
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("input_ver", "expected"),
+    [
+        ("1", "1.0.0"),
+        ("1.2", "1.2.0"),
+        ("1.2.3", "1.2.3"),
+        ("1.2.3-beta.1", "1.2.3-beta.1"),
+        ("1.2.3+meta", "1.2.3+meta"),
+        (" 1.2.3 ", "1.2.3"),
+    ],
+)
+def test_version_coercion(input_ver: str, expected: str) -> None:
+    meta = AssetMetadata(id="v", kind="prompt", version=input_ver, description="d")
+    assert meta.version == expected
+
+
+def test_version_coerces_via_from_dict() -> None:
+    meta = AssetMetadata.from_dict(
+        {"id": "v", "kind": "prompt", "version": "0", "description": "d"}
+    )
+    assert meta.version == "0.0.0"
+
+
+# -----------------------------------------------------------------------
+# ID normalisation
+# -----------------------------------------------------------------------
+
+
+def test_id_is_lowercased_and_stripped() -> None:
+    meta = AssetMetadata(
+        id="  My-Asset_ID ",
+        kind="prompt",
+        version="1.0.0",
+        description="d",
+    )
+    assert meta.id == "my-asset_id"
+
+
+def test_id_rejects_blank() -> None:
+    with pytest.raises(AssetValidationError):
+        AssetMetadata.from_dict(
+            {
+                "id": "  ",
+                "kind": "prompt",
+                "version": "1.0.0",
+                "description": "d",
+            }
+        )
+
+
+# -----------------------------------------------------------------------
+# Invalid kinds are rejected
+# -----------------------------------------------------------------------
+
+
+def test_invalid_kind_rejected() -> None:
+    with pytest.raises(AssetValidationError):
+        AssetMetadata.from_dict(
+            {
+                "id": "x",
+                "kind": "flashlight",
+                "version": "1.0.0",
+                "description": "d",
+            }
+        )
+
+
+# -----------------------------------------------------------------------
+# Tags normalisation and dedup
+# -----------------------------------------------------------------------
+
+
+def test_tags_coerce_single_string_to_tuple() -> None:
+    meta = AssetMetadata(
+        id="t",
+        kind="prompt",
+        version="1.0.0",
+        description="d",
+        tags=["alpha", "beta"],
+    )
+    assert meta.tags == ("alpha", "beta")
+
+
+def test_tags_deduplicate() -> None:
+    meta = AssetMetadata(
+        id="td",
+        kind="prompt",
+        version="1.0.0",
+        description="d",
+        tags=["a", "a", "b"],
+    )
+    assert meta.tags == ("a", "b")
+
+
+def test_tags_empty_strings_filtered() -> None:
+    meta = AssetMetadata(
+        id="te",
+        kind="prompt",
+        version="1.0.0",
+        description="d",
+        tags=["a", "  ", "b"],
+    )
+    assert meta.tags == ("a", "b")
+
+
+# -----------------------------------------------------------------------
+# Required providers normalisation
+# -----------------------------------------------------------------------
+
+
+def test_required_providers_normalized_and_deduped() -> None:
+    meta = AssetMetadata(
+        id="rp",
+        kind="prompt",
+        version="1.0.0",
+        description="d",
+        required_providers=["Fake-Model", "fake-model", "honcho"],
+    )
+    assert meta.required_providers == ("fake-model", "honcho")
+
+
+# -----------------------------------------------------------------------
+# Profile filter validation
+# -----------------------------------------------------------------------
+
+
+def test_profile_filter_requires_op() -> None:
+    with pytest.raises(AssetValidationError):
+        AssetMetadata.from_dict(
+            {
+                "id": "pf",
+                "kind": "prompt",
+                "version": "1.0.0",
+                "description": "d",
+                "profile_filter": [{"tag": "ea"}],
+            }
+        )
+
+
+def test_profile_filter_valid_include() -> None:
+    meta = AssetMetadata.from_dict(
+        {
+            "id": "pf",
+            "kind": "prompt",
+            "version": "1.0.0",
+            "description": "d",
+            "profile_filter": [{"op": "include", "tag": "ea"}],
+        }
+    )
+    assert meta.profile_filter == ({"op": "include", "tag": "ea"},)
+
+
+def test_profile_filter_invalid_op_rejected() -> None:
+    with pytest.raises(AssetValidationError):
+        AssetMetadata.from_dict(
+            {
+                "id": "pf",
+                "kind": "prompt",
+                "version": "1.0.0",
+                "description": "d",
+                "profile_filter": [{"op": "skip", "tag": "ea"}],
+            }
+        )
+
+
+def test_profile_filter_empty_list_allowed() -> None:
+    meta = AssetMetadata.from_dict(
+        {
+            "id": "pf",
+            "kind": "prompt",
+            "version": "1.0.0",
+            "description": "d",
+            "profile_filter": [],
+        }
+    )
+    assert meta.profile_filter == ()
+
+
+def test_profile_filter_none_allowed() -> None:
+    meta = AssetMetadata.from_dict(
+        {
+            "id": "pf",
+            "kind": "prompt",
+            "version": "1.0.0",
+            "description": "d",
+            "profile_filter": None,
+        }
+    )
+    assert meta.profile_filter == ()
+
+
+# -----------------------------------------------------------------------
+# Kind-specific metadata models
+# -----------------------------------------------------------------------
+
+
+def test_routine_metadata_has_extra_fields() -> None:
+    meta = RoutineMetadata(
+        id="briefing",
+        kind="routine",
+        version="1.0.0",
+        description="a briefing",
+        milestones=("intake", "plan"),
+        emits_events=("run.progress",),
+    )
+    assert meta.milestones == ("intake", "plan")
+    assert meta.emits_events == ("run.progress",)
+
+
+def test_agent_metadata_enforces_max_tools_per_step_minimum() -> None:
+    with pytest.raises(Exception):  # noqa PT011
+        AgentMetadata(
+            id="bad-agent",
+            kind="agent",
+            version="1.0.0",
+            description="d",
+            max_tools_per_step=0,
+        )
+
+
+def test_policy_metadata_enforce_mode() -> None:
+    meta = PolicyMetadata(
+        id="strict",
+        kind="policy",
+        version="1.0.0",
+        description="strict policy",
+        enforce_mode="block",
+    )
+    assert meta.enforce_mode == "block"
+
+
+def test_kind_literal_stick() -> None:
+    """Each kind-specific model locks its ``kind`` literal."""
+    assert RoutineMetadata(kind="routine", id="r", version="1.0", description="d").kind == "routine"
+    assert WidgetMetadata(kind="widget", id="w", version="1.0", description="d").kind == "widget"
+    assert CommandMetadata(kind="command", id="c", version="1.0", description="d").kind == "command"
+    assert PromptMetadata(kind="prompt", id="p", version="1.0", description="d").kind == "prompt"
+    assert ToolMetadata(kind="tool", id="t", version="1.0", description="d").kind == "tool"
+    assert SkillMetadata(kind="skill", id="s", version="1.0", description="d").kind == "skill"
+    assert (
+        AgentMetadata(
+            kind="agent",
+            id="a",
+            version="1.0",
+            description="d",
+            max_tools_per_step=1,
+        ).kind
+        == "agent"
+    )
+    assert TeamMetadata(kind="team", id="tm", version="1.0", description="d").kind == "team"
+    assert (
+        PipelineMetadata(kind="pipeline", id="pl", version="1.0", description="d").kind
+        == "pipeline"
+    )
+    assert PolicyMetadata(kind="policy", id="po", version="1.0", description="d").kind == "policy"
+    assert ThemeMetadata(kind="theme", id="th", version="1.0", description="d").kind == "theme"
+    assert (
+        ContextProviderMetadata(
+            kind="context_provider",
+            id="cp",
+            version="1.0",
+            description="d",
+        ).kind
+        == "context_provider"
+    )
+    assert (
+        ProfileOverlayMetadata(
+            kind="profile_overlay",
+            id="po2",
+            version="1.0",
+            description="d",
+        ).kind
+        == "profile_overlay"
+    )
+
+
+# -----------------------------------------------------------------------
+# JSON schema export
+# -----------------------------------------------------------------------
+
+
+def test_to_json_schema_returns_dict() -> None:
+    meta = AssetMetadata(
+        id="base",
+        kind="prompt",
+        version="1.0.0",
+        description="d",
+    )
+    schema = meta.to_json_schema()
+    assert isinstance(schema, dict)
+    assert "properties" in schema
+
+
+# -----------------------------------------------------------------------
+# Cross-asset duplicate-id validation
+# -----------------------------------------------------------------------
+
+
+def test_validate_unique_ids_passes() -> None:
+    assets = [
+        AssetMetadata(id="alpha", kind="prompt", version="1.0", description="d"),
+        AssetMetadata(id="beta", kind="widget", version="1.0", description="d"),
+    ]
+    assert validate_unique_ids(assets) == []
+
+
+def test_validate_unique_ids_catches_duplicates_across_kinds() -> None:
+    assets = [
+        AssetMetadata(id="dup", kind="prompt", version="1.0", description="d"),
+        AssetMetadata(id="dup", kind="widget", version="1.0", description="d"),
+    ]
+    errors = validate_unique_ids(assets)
+    assert len(errors) == 1
+    assert "dup" in errors[0]
+
+
+def test_validate_unique_ids_no_duplicates_same_kind() -> None:
+    assets = [
+        AssetMetadata(id="x", kind="prompt", version="1.0", description="d"),
+        AssetMetadata(id="x", kind="prompt", version="1.0", description="d"),
+    ]
+    errors = validate_unique_ids(assets)
+    assert len(errors) == 1
+
+
+# -----------------------------------------------------------------------
+# All known asset kinds are valid
+# -----------------------------------------------------------------------
+
+
+def test_all_known_kinds_accepted() -> None:
+    for kind in KNOWN_ASSET_KINDS:
+        AssetMetadata(
+            id=f"asset-for-{kind}",
+            kind=kind,
+            version="1.0.0",
+            description="test",
+        )
+
+
+def test_current_profile_extension_examples_are_known_kinds() -> None:
+    from waywarden.domain.profile import (
+        CURRENT_PROFILE_EXTENSION_EXAMPLES,
+    )
+
+    assert KNOWN_ASSET_KINDS == CURRENT_PROFILE_EXTENSION_EXAMPLES


### PR DESCRIPTION
# P5-1: Shared-asset metadata schema

## Summary
Delivers the canonical metadata schema for every shared asset under .

## What was implemented
- **Pydantic v2  model** with common base fields: id, kind, version, description, tags, required_providers, profile_filter
- **13 kind-specific sub-classes**: Routine, Widget, Command, Prompt, Tool, Skill, Agent, Team, Pipeline, Policy, Theme, ContextProvider, ProfileOverlay
- **Version coercion** to strict  semver form
- **ID normalisation** (lowercase + strip)
- **Tags deduplication** and whitespace trimming
- **Required-providers normalisation** (lowercase + dedup)
- **Profile-filter validation** with required  field
- **JSON Schema export** via 
- **Cross-asset duplicate ID validator** ()
- **Sample asset.yaml** under 
- **31 unit tests** covering all validation paths

## Acceptance criteria
- [x] Pydantic v2 metadata model per asset kind plus common base
- [x] JSON-schema export for tooling
- [x] Repo convention:  plus kind-specific payload
- [x] Fail-fast loader validation (no silent coercion)
- [x] Tests covering required fields, invalid kinds, version coercion, and duplicate ids across kinds

## Validation
- 31/31 tests passing
- mypy: success (no issues)
- ruff: all checks passed