### PR TITLE
P5-3: EA profile overlay hydration (#83)

### DIFF
--- a/src/waywarden/profiles/ea/__init__.py
+++ b/src/waywarden/profiles/ea/__init__.py
@@ -1,1 +1,16 @@
-"""Temporary EA-specific modules pending the first real profile overlay."""
+"""EA profile overlay hydration (P5-3 #83).
+
+Provides the ``EAProfileView`` and hydration logic for the EA profile.
+"""
+
+from waywarden.profiles.ea.hydrate import (
+    EAProfileView,
+    ProfileHydrationError,
+    hydrate_ea_profile,
+)
+
+__all__ = [
+    "EAProfileView",
+    "ProfileHydrationError",
+    "hydrate_ea_profile",
+]

--- a/src/waywarden/profiles/ea/hydrate.py
+++ b/src/waywarden/profiles/ea/hydrate.py
@@ -1,0 +1,227 @@
+"""EA profile overlay hydration (P5-3 #83).
+
+Hydrates ``profiles/ea/profile.yaml`` into a typed EA profile that:
+- declares its required providers via ``RequiredProviders``
+- resolves asset-filter expansions through the AssetRegistry
+- fails fast on startup when required providers or assets are missing
+
+Canonical references:
+    - ADR 0002 (core + profile packs)
+    - ADR 0006 (V1 roadmap)
+    - P3-2 #53 (profile.required_providers)
+    - P5-2 #82 (AssetRegistry)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from waywarden.assets.loader import AssetRegistry
+from waywarden.assets.schema import AssetMetadata
+from waywarden.domain.profile import (
+    ProfileDescriptor,
+    ProfileId,
+    ProfileRegistry,
+    RequiredProviders,
+)
+
+# ---------------------------------------------------------------------------
+# Domain error
+# ---------------------------------------------------------------------------
+
+
+class ProfileHydrationError(RuntimeError):
+    """Raised when EA profile hydration fails."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:
+        lines = ["EA profile hydration failed:"]
+        lines.extend(f"- {error}" for error in self.errors)
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Enriched profile descriptor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EAProfileView:
+    """Enriched EA profile view with hydrated asset filters.
+
+    This is the runtime-visible profile after PLC-3 hydration.
+    """
+
+    descriptor: ProfileDescriptor
+    asset_filters: list[dict[str, Any]] = field(
+        default_factory=list
+    )
+    resolved_assets: list[AssetMetadata] = field(
+        default_factory=list
+    )
+
+    @property
+    def id(self) -> ProfileId:
+        return self.descriptor.id
+
+    @property
+    def display_name(self) -> str:
+        return self.descriptor.display_name
+
+    @property
+    def required_providers(self) -> RequiredProviders:
+        return self.descriptor.required_providers
+
+
+# ---------------------------------------------------------------------------
+# Hydration engine
+# ---------------------------------------------------------------------------
+
+
+def hydrate_ea_profile(
+    profile_path: Path | None = None,
+    *,
+    profile_registry: ProfileRegistry | None = None,
+    asset_registry: AssetRegistry | None = None,
+    registry_assets_dir: str = "assets",
+) -> EAProfileView:
+    """Hydrate the EA profile from its YAML manifest.
+
+    Args:
+        profile_path: Path to the EA profile YAML (``profiles/ea/profile.yaml``).
+            If not supplied, looks up ``profiles/ea/profile.yaml``
+            relative to cwd.
+        profile_registry: Optional pre-built ProfileRegistry.
+            If not supplied, the default EA profile is loaded.
+        asset_registry: Optional pre-built AssetRegistry for filter expansion.
+        registry_assets_dir: Directory to pass to ``AssetRegistry.load_from_dir``.
+
+    Raises:
+        ProfileHydrationError: When any validation or resolution fails.
+    """
+    errors: list[str] = []
+
+    # 1. Load the raw profile descriptor from YAML.
+    raw_profile = _load_raw_profile(profile_path, errors)
+    if profile_registry is None:
+        profile_registry = _build_profile_registry(raw_profile, errors)
+
+    # 2. Get the EA profile descriptor.
+    ea_descriptor = _get_ea_descriptor(
+        profile_registry, errors
+    )
+
+    # 3. Extract ``asset_filters`` from the raw YAML.
+    asset_filters = raw_profile.get("asset_filters", [])
+
+    # 4. Expand filters through the asset registry.
+    asset_reg = asset_registry
+    if asset_reg is None:
+        asset_reg = AssetRegistry()
+        asyncio_run_once(
+            asset_reg.load_from_dir(registry_assets_dir)
+        )
+
+    resolved_assets: list[AssetMetadata] = []
+    if asset_filters and asset_reg.is_valid:
+        resolved_assets = asset_reg.apply_filters(asset_filters)
+
+    # 5. Collect all errors.
+    errors.extend(asset_reg.errors)
+
+    if errors:
+        raise ProfileHydrationError(errors) from None
+
+    return EAProfileView(
+        descriptor=ea_descriptor,
+        asset_filters=asset_filters if asset_filters else [],
+        resolved_assets=resolved_assets,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+_ASYNC_RUN_CACHE: dict[int, Any] = {}
+
+
+def asyncio_run_once(coro: Any) -> None:
+    """Run an asyncio coroutine once, caching the result."""
+    key = id(coro)
+    if key not in _ASYNC_RUN_CACHE:
+        import asyncio
+
+        _ASYNC_RUN_CACHE[key] = asyncio.get_event_loop().run_until_complete(
+            coro
+        )
+
+
+def _load_raw_profile(
+    profile_path: Path | None, errors: list[str]
+) -> dict[str, Any]:
+    if profile_path is None:
+        profile_path = Path("profiles/ea/profile.yaml")
+    try:
+        content = yaml.safe_load(
+            profile_path.read_text(encoding="utf-8")
+        )
+    except OSError as exc:
+        errors.append(f"{profile_path}: read error: {exc}")
+        return {}
+    if content is None or not isinstance(content, dict):
+        errors.append(
+            f"{profile_path}: expected a mapping of profile settings"
+        )
+        return {}
+    return content if isinstance(content, dict) else {}
+
+
+def _build_profile_registry(
+    raw: dict[str, Any], errors: list[str]
+) -> ProfileRegistry:
+    """Build a minimal ProfileRegistry from a raw YAML dict."""
+    try:
+        raw_providers = raw.get("required_providers", {})
+        required_providers = RequiredProviders(**raw_providers)
+    except (TypeError, ValueError) as exc:
+        errors.append(f"required_providers: {exc}")
+        required_providers = RequiredProviders(
+            model="", memory="", knowledge="", tracer=""
+        )
+
+    supported_extensions = tuple(
+        raw.get("supported_extensions", [])
+    )
+
+    descriptor = ProfileDescriptor(
+        id=raw.get("id", "ea-noop"),
+        display_name=raw.get("display_name", "EA No-Op"),
+        version=raw.get("version", "0.0.0"),
+        supported_extensions=supported_extensions,
+        required_providers=required_providers,
+    )
+    return ProfileRegistry({descriptor.id: descriptor})
+
+
+def _get_ea_descriptor(
+    registry: ProfileRegistry, errors: list[str]
+) -> ProfileDescriptor:
+    """Return the EA profile descriptor or record an error."""
+    try:
+        return registry["ea"]
+    except KeyError:
+        errors.append(
+            "EA profile ('ea') not found in profile registry; "
+            "checked-in profiles: "
+            f"{[p.id for p in registry.list()]}"
+        )
+        raise ProfileHydrationError(errors) from None

--- a/tests/unit/test_ea_profile_hydration.py
+++ b/tests/unit/test_ea_profile_hydration.py
@@ -1,0 +1,163 @@
+"""Tests for EA profile overlay hydration (P5-3 #83)."""
+
+from pathlib import Path
+
+import pytest
+
+from waywarden.assets.loader import AssetRegistry
+from waywarden.domain.profile import (
+    ProfileDescriptor,
+    ProfileId,
+    ProfileRegistry,
+    RequiredProviders,
+)
+from waywarden.profiles.ea.hydrate import (
+    EAProfileView,
+    ProfileHydrationError,
+    hydrate_ea_profile,
+)
+
+FIXTURES_DIR = Path("tests/fixtures/assets").resolve()
+EA_PROFILE_PATH = Path("profiles/ea/profile.yaml")
+
+
+# -----------------------------------------------------------------------
+# Happy path
+# -----------------------------------------------------------------------
+
+
+def test_hydrate_ea_profile_creates_view() -> None:
+    """Hydration succeeds with the real EA profile."""
+    view = hydrate_ea_profile(
+        profile_path=EA_PROFILE_PATH,
+        asset_registry=_default_asset_registry(),
+    )
+    assert isinstance(view, EAProfileView)
+    assert view.id == ProfileId("ea")
+    assert view.display_name == "Executive Assistant"
+
+
+def test_hydrate_ea_profile_resolves_asset_filters() -> None:
+    """When asset filters are present, resolved_assets is populated."""
+    view = hydrate_ea_profile(
+        profile_path=EA_PROFILE_PATH,
+        asset_registry=_default_asset_registry(),
+    )
+    assert isinstance(view.asset_filters, list)
+    # The EA profile has no asset_filters (only required_providers + supported_extensions)
+    # So resolved should be empty — which is still valid
+    assert view.resolved_assets == []
+
+
+def test_hydrate_with_custom_registry() -> None:
+    """Hydration with a custom ProfileRegistry."""
+    descriptor = ProfileDescriptor(
+        id="ea",
+        display_name="EA",
+        version="1.0.0",
+        supported_extensions=("widget", "command"),
+        required_providers=RequiredProviders(
+            model="fake-model",
+            memory="fake-memory",
+            knowledge="fake-knowledge",
+            tracer="noop",
+        ),
+    )
+    reg = ProfileRegistry({"ea": descriptor})
+    view = hydrate_ea_profile(
+        profile_path=EA_PROFILE_PATH,
+        profile_registry=reg,
+        asset_registry=_default_asset_registry(),
+    )
+    assert view.id == ProfileId("ea")
+
+
+# -----------------------------------------------------------------------
+# Missing provider error
+# -----------------------------------------------------------------------
+
+
+def test_hydrate_fails_when_ea_missing_from_registry() -> None:
+    """Hydration raises when profile registry lacks 'ea'."""
+    desc = ProfileDescriptor(
+        id="coding",
+        display_name="Coding",
+        version="1.0.0",
+        supported_extensions=("command",),
+        required_providers=RequiredProviders(
+            model="m", memory="m", knowledge="m", tracer="noop",
+        ),
+    )
+    reg = ProfileRegistry({"coding": desc})
+    with pytest.raises(ProfileHydrationError) as exc_info:
+        hydrate_ea_profile(
+            profile_path=EA_PROFILE_PATH,
+            profile_registry=reg,
+        )
+    assert any("EA profile" in str(e) for e in exc_info.value.errors)
+
+
+# -----------------------------------------------------------------------
+# Missing asset error propagation
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hydrate_propagates_asset_load_errors() -> None:
+    """When asset loading fails, hydration records the error."""
+    bad_reg = AssetRegistry()
+    await bad_reg.load_from_dir(Path("/no/directory"))
+    # The registry is invalid; hydration should surface this
+    with pytest.raises(ProfileHydrationError):
+        hydrate_ea_profile(
+            profile_path=EA_PROFILE_PATH,
+            asset_registry=bad_reg,
+        )
+
+
+# -----------------------------------------------------------------------
+# EAProfileView fields
+# -----------------------------------------------------------------------
+
+
+def test_ea_profile_view_proxies_id() -> None:
+    desc = ProfileDescriptor(
+        id="ea",
+        display_name="EA",
+        version="1.0.0",
+        supported_extensions=("a",),
+        required_providers=RequiredProviders(
+            model="x", memory="x", knowledge="x", tracer="noop",
+        ),
+    )
+    view = EAProfileView(descriptor=desc)
+    assert view.id == ProfileId("ea")
+    assert view.display_name == "EA"
+
+
+def test_ea_profile_view_required_providers_proxy() -> None:
+    providers = RequiredProviders(
+        model="m", memory="m", knowledge="m", tracer="noop",
+    )
+    desc = ProfileDescriptor(
+        id="ea", display_name="EA", version="1.0.0",
+        supported_extensions=("a",), required_providers=providers,
+    )
+    view = EAProfileView(descriptor=desc)
+    assert view.required_providers == providers
+
+
+# -----------------------------------------------------------------------
+# Internal helpers
+# -----------------------------------------------------------------------
+
+
+def _default_asset_registry() -> AssetRegistry:
+    """Return an AssetRegistry pre-loaded with fixture data."""
+    reg = AssetRegistry()
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(
+        reg.load_from_dir(FIXTURES_DIR)
+    )
+    return reg


### PR DESCRIPTION
P5-3: EA profile overlay hydration

## Summary
Hydrates the EA profile YAML into a typed `EAProfileView` with asset-filter expansion and validation.

## What was implemented
- **Typed EAProfileView** with `required_providers` and `resolved_assets`
- **YAML-based hydration** via `hydrate_ea_profile()`
- **Asset-filter expansion** through the P5-2 AssetRegistry
- **Fail-fast on startup** when required providers or assets are missing
- **7 unit tests** covering happy path, missing provider, missing assets

## Dependencies satisfied
- P3-2 #53: Profile.required_providers is green (CLOSED)
- P5-2 #82: Asset loader is green (MERGED)

## Validation
- 63/63 tests passing (schema + loader + hydration)
- mypy: success
- ruff: all checks passed