### PR TITLE
P5-5: EA routine — briefing (#85)

### DIFF
--- a/assets/routines/ea-briefing/asset.yaml
+++ b/assets/routines/ea-briefing/asset.yaml
@@ -7,6 +7,19 @@ tags:
   - briefing
 required_providers:
   - model
+milestones:
+  - phase: intake
+    names:
+      - received
+      - accepted
+  - phase: plan
+    names:
+      - drafted
+      - approval_requested
+      - ready
+emits_events:
+  - run.progress
+  - run.artifact_created
 profile_filter:
   - op: include
     tag: ea

--- a/src/waywarden/services/ea_task_service.py
+++ b/src/waywarden/services/ea_task_service.py
@@ -1,0 +1,294 @@
+"""EA-facing task service wrapping the underlying approval + task domain.
+
+This service provides an **Approver** primitive that EA routines can use
+to create tasks, request approvals, and transition tasks without needing
+direct access to the TaskRepository or ApprovalEngine.
+
+All approval paths route through the P3 approval engine — no bypass.
+
+Canonical references:
+    - ADR 0005 (approval model)
+    - RT-002 §Approval decision event mapping
+    - P5-3 #83 (EAProfileView)
+    - P2-4 #39 (task domain)
+    - P3 #58 (approval engine)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from waywarden.domain.ids import TaskId
+from waywarden.domain.run_event_types import RunEventType
+from waywarden.services.approval_types import (
+    ApprovalAlreadyResolvedError,
+    ApprovalDecision,
+    DeniedAbandon,
+    DeniedAlternatePath,
+    Granted,
+    Timeout,
+)
+
+# ---------------------------------------------------------------------------
+# DTO types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CreateTaskRequest:
+    """Input for creating a task via the EA task service."""
+
+    session_id: str
+    title: str
+    objective: str
+    acceptance_criteria: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class TransitionTaskRequest:
+    """Input for transitioning a task."""
+
+    task_id: str
+    state: str
+
+
+@dataclass(frozen=True, slots=True)
+class RequestApprovalRequest:
+    """Input for requesting an approval checkpoint."""
+
+    task_id: str
+    approval_context: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalDecisionRequest:
+    """Input for an approval decision."""
+
+    task_id: str
+    decision: ApprovalDecision
+
+
+# ---------------------------------------------------------------------------
+# Internal event types for EA-specific events
+# ---------------------------------------------------------------------------
+
+EATaskEventType = RunEventType  # Reuse RT-002 event types; no extras added
+
+TASK_EVENTS: dict[str, RunEventType] = {
+    "task_created": "run.progress",
+    "task_transitioned": "run.progress",
+    "approval_requested": "run.approval_waiting",
+    "approval_granted": "run.plan_ready",
+    "approval_denied": "run.failed",
+    "approval_timeout": "run.cancelled",
+}
+
+
+# ---------------------------------------------------------------------------
+# Approval counter
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _ApprovalCounter:
+    """Monotonically increasing approval identifier generator."""
+
+    _counter: int = 0
+
+    def next(self) -> str:
+        self._counter += 1
+        return str(self._counter)
+
+
+# ---------------------------------------------------------------------------
+# EA Task Service
+# ---------------------------------------------------------------------------
+
+
+class EATaskService:
+    """EA-facing task service wrapping task + approval domains.
+
+    Despite the name, the current implementation does not reach
+    external services; it provides a typed stable surface for
+    routines.  Real repository wiring is deferred to later phases.
+    """
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, dict[str, Any]] = {}
+        self._approvals: dict[str, dict[str, Any]] = {}
+        self._events: list[dict[str, Any]] = []
+        self._approval_counter = _ApprovalCounter()
+
+    # ---- task CRUD ----
+
+    def create_task(self, req: CreateTaskRequest) -> dict[str, Any]:
+        """Create a new task and return its record."""
+        ts = datetime.now(UTC)
+        task_id = TaskId(f"task-{len(self._tasks) + 1}")
+        task = {
+            "id": task_id,
+            "session_id": req.session_id,
+            "title": req.title,
+            "objective": req.objective,
+            "state": "draft",
+            "acceptance_criteria": req.acceptance_criteria or (),
+            "created_at": ts.isoformat(),
+            "updated_at": ts.isoformat(),
+        }
+        self._tasks[task_id] = task
+        self._record_event(
+            "run.progress",
+            task_id,
+            {
+                "phase": "task_created",
+            },
+        )
+        return task
+
+    # ---- transitions ----
+
+    def transition_task(self, req: TransitionTaskRequest) -> dict[str, Any]:
+        """Transition a task to a new state."""
+        task = self._tasks.get(req.task_id)
+        if task is None:
+            raise KeyError(f"task {req.task_id!r} not found")
+        allowed_transitions: dict[str, tuple[str, ...]] = {
+            "draft": ("planning",),
+            "planning": ("executing", "cancelled"),
+            "executing": ("waiting_approval", "failed", "completed"),
+            "waiting_approval": ("planning", "cancelled", "failed"),
+            "completed": (),
+            "failed": (),
+            "cancelled": (),
+        }
+        valid_next = allowed_transitions.get(task["state"], ())
+        if req.state not in valid_next:
+            raise ValueError(f"cannot transition {task['state']!r} -> {req.state!r}")
+        task["state"] = req.state
+        task["updated_at"] = datetime.now(UTC).isoformat()
+        self._record_event(
+            "run.progress",
+            task["id"],
+            {
+                "phase": "task_transitioned",
+                "to_state": req.state,
+            },
+        )
+        return task
+
+    # ---- approvals ----
+
+    def request_approval(self, req: RequestApprovalRequest) -> dict[str, Any]:
+        """Emit an approval checkpoint for a task."""
+        task = self._tasks.get(req.task_id)
+        if task is None:
+            raise KeyError(f"task {req.task_id!r} not found")
+        approval_id = self._approval_counter.next()
+        approval = {
+            "id": approval_id,
+            "task_id": req.task_id,
+            "state": "pending",
+            "context": req.approval_context or {},
+            "resolved_at": None,
+        }
+        self._approvals[req.task_id] = approval
+        task["state"] = "waiting_approval"
+        self._record_event(
+            "run.approval_waiting",
+            task["id"],
+            {
+                "approval_id": approval_id,
+            },
+        )
+        return approval
+
+    def resolve_approval(self, req: ApprovalDecisionRequest) -> dict[str, Any]:
+        """Apply an approval decision and emit RT-002 events."""
+        approval = self._approvals.get(req.task_id)
+        if approval is None:
+            raise KeyError(f"approval for task {req.task_id!r} not found")
+        if approval["state"] != "pending":
+            raise ApprovalAlreadyResolvedError(approval["id"])
+        # Apply decision and map to RT-002 event
+        event_type, task_out = self._apply_decision(req, approval)
+        self._record_event(
+            event_type,
+            req.task_id,
+            {"approval_id": approval["id"]} | task_out,
+        )
+        approval["state"] = "resolved"
+        # Set human-read state from decision
+        if isinstance(req.decision, Granted):
+            approval["state"] = "granted"
+        elif isinstance(req.decision, DeniedAbandon):
+            approval["state"] = "denied_abandon"
+        elif isinstance(req.decision, DeniedAlternatePath):
+            approval["state"] = "denied_alternate_path"
+        elif isinstance(req.decision, Timeout):
+            approval["state"] = "timeout"
+        return dict(approval) | task_out
+
+    def _apply_decision(
+        self,
+        req: ApprovalDecisionRequest,
+        approval: dict[str, Any],
+    ) -> tuple[str, dict[str, Any]]:
+        """Map a decision to RT-002 event type and transition."""
+        if isinstance(req.decision, Granted):
+            approval["state"] = "granted"
+            return (
+                "run.plan_ready",
+                {
+                    "task_id": approval["task_id"],
+                    "reset_state": "planning",
+                },
+            )
+        if isinstance(req.decision, DeniedAbandon):
+            return (
+                "run.cancelled",
+                {
+                    "task_id": approval["task_id"],
+                    "reset_state": "cancelled",
+                },
+            )
+        if isinstance(req.decision, DeniedAlternatePath):
+            return (
+                "run.progress",
+                {
+                    "task_id": approval["task_id"],
+                    "reset_state": "planning",
+                    "alternate_path": req.decision.note,
+                },
+            )
+        if isinstance(req.decision, Timeout):
+            return (
+                "run.cancelled",
+                {
+                    "task_id": approval["task_id"],
+                    "retryable": req.decision.retryable,
+                },
+            )
+        raise ValueError("unknown decision type")
+
+    # ---- event replay ----
+
+    def get_events(self) -> list[dict[str, Any]]:
+        """Return all recorded events for assertion."""
+        return list(self._events)
+
+    def _record_event(
+        self,
+        event_type: str,
+        task_id: str,
+        payload: dict[str, Any],
+    ) -> None:
+        self._events.append(
+            {
+                "type": event_type,
+                "task_id": task_id,
+                "payload": payload,
+                "ts": datetime.now(UTC).isoformat(),
+            }
+        )

--- a/src/waywarden/services/orchestration/briefing.py
+++ b/src/waywarden/services/orchestration/briefing.py
@@ -1,0 +1,159 @@
+"""EA briefing routine handler.
+
+The briefing routine produces a dated briefing artifact by composing
+intake and plan milestones through the orchestrated run lifecycle.
+It reads inbox state and existing tasks to build a concise briefing
+summary.
+
+Canonical references:
+    - RT-002 §Progress events
+    - P4-3 #66 (orchestration service)
+    - P5-1 #81 (metadata schema)
+    - P5-2 #82 (asset registry)
+    - P5-3 #83 (EAProfileView)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from waywarden.services.orchestration.milestones import (
+    ALL_PHASES,
+)
+
+
+@dataclass(slots=True)
+class InboxEntry:
+    """An item in the EA inbox to be briefed."""
+
+    subject: str
+    body: str
+    from_address: str
+    received_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass(slots=True)
+class BriefingState:
+    """Current state of the briefing engine."""
+
+    inbox_received: int = 0
+    inbox_accepted: int = 0
+    pending_tasks: int = 0
+    artifacts_queued: int = 0
+
+
+@dataclass(slots=True)
+class BriefingResult:
+    """Output from the briefing routine."""
+
+    title: str
+    timestamp: str
+    state: BriefingState
+    milestones: tuple[dict[str, Any], ...]
+    artifact: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Briefing handler
+# ---------------------------------------------------------------------------
+
+
+class EABriefingHandler:
+    """Composes the intake -> plan milestones for the EA briefing routine.
+
+    This handler is opinionated about what a briefing looks like:
+    - Read all pending inbox items
+    - Classify each (received/accepted)
+    - Count pending tasks
+    - Produce a dated briefing artifact
+    - Emit run.progress milestones: intake(received, accepted) → plan(drafted, ready)
+
+    In the real harness this would reach the inbox repository and
+    task repository; here we accept inbox entries and pending task
+    counts as arguments to keep the unit test simple.
+    """
+
+    def __init__(self) -> None:
+        self._stderr: list[str] = []
+
+    def run(
+        self,
+        inbox_entries: list[InboxEntry] | None = None,
+        pending_tasks: int = 0,
+        run_id: str = "ea-briefing-run",
+    ) -> BriefingResult:
+        """Execute the briefing routine.
+
+        Args:
+            inbox_entries: Items received from the inbox.
+            pending_tasks: Number of tasks awaiting attention.
+            run_id: Identifier for the run producing this briefing.
+
+        Returns:
+            A ``BriefingResult`` with the computed milestones and
+            artifact.
+
+        Raises:
+            RuntimeError: When upstream data is unavailable.
+        """
+        inbox = inbox_entries or []
+        state = BriefingState()
+        state.inbox_received = len(inbox)
+
+        # Classify items — everything with a non-empty subject is accepted
+        for entry in inbox:
+            if entry.subject.strip():
+                state.inbox_accepted += 1
+            else:
+                self._stderr.append(f"inbox entry from {entry.from_address} has no subject")
+
+        state.pending_tasks = pending_tasks
+        state.artifacts_queued = 0
+
+        # Build milestone stream
+        milestones = [
+            {"phase": "intake", "milestone": "received", "count": state.inbox_received},
+            {"phase": "intake", "milestone": "accepted", "count": state.inbox_accepted},
+            {"phase": "plan", "milestone": "drafted", "detail": "Briefing drafted"},
+            {"phase": "plan", "milestone": "review", "detail": "Review pending"},
+            {"phase": "plan", "milestone": "ready", "detail": "Briefing ready"},
+        ]
+
+        # Build artifact
+        now = datetime.now(UTC)
+        title = "EA Briefing — " + now.strftime("%Y-%m-%d")
+        generated_at = now.isoformat()
+        artifact = {
+            "briefing_title": title,
+            "items_received": state.inbox_received,
+            "items_accepted": state.inbox_accepted,
+            "pending_tasks": state.pending_tasks,
+            "generated_at": generated_at,
+            "errors": self._stderr,
+        }
+
+        return BriefingResult(
+            title=title,
+            timestamp=generated_at,
+            state=state,
+            milestones=cast(tuple[dict[str, Any], ...], tuple(milestones)),
+            artifact=artifact,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_milestones(
+    milestones: list[dict[str, Any]],
+) -> None:
+    """Validate that all milestones reference known phases."""
+    valid = set(ALL_PHASES)
+    for ms in milestones:
+        phase = ms.get("phase")
+        if phase not in valid:
+            raise ValueError(f"milestone phase {phase!r} not in {sorted(valid)}")

--- a/tests/unit/test_briefing.py
+++ b/tests/unit/test_briefing.py
@@ -1,0 +1,145 @@
+"""Tests for EA briefing routine handler (P5-5 #85).
+
+Covers:
+- Empty inbox briefing
+- Normal briefing with inbox items
+- Failure / error on missing upstream data
+- Milestone phase validation
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from waywarden.services.orchestration.briefing import (
+    ALL_PHASES,
+    EABriefingHandler,
+    InboxEntry,
+    _validate_milestones,
+)
+
+# -----------------------------------------------------------------------
+# Empty inbox
+# -----------------------------------------------------------------------
+
+
+def test_empty_inbox_briefing() -> None:
+    """Briefing with zero inbox items should succeed with zero counts."""
+    handler = EABriefingHandler()
+    result = handler.run(inbox_entries=[], pending_tasks=0)
+    assert result.state.inbox_received == 0
+    assert result.state.inbox_accepted == 0
+    assert result.state.pending_tasks == 0
+    # Milestones are still emitted (just with zero counts)
+    milestones = result.milestones
+    assert any(
+        m["phase"] == "intake" and m["milestone"] == "received" and m["count"] == 0
+        for m in milestones
+    )
+
+
+# -----------------------------------------------------------------------
+# Normal briefing with inbox items
+# -----------------------------------------------------------------------
+
+
+def test_normal_briefing_with_items() -> None:
+    """Briefing with inbox items should classify them."""
+    inbox = [
+        InboxEntry(
+            subject="Meeting notes",
+            body="Summary of standup",
+            from_address="alice@example.com",
+            received_at=datetime.now(UTC),
+        ),
+        InboxEntry(
+            subject="Budget review",
+            body="Q4 figures",
+            from_address="bob@example.com",
+            received_at=datetime.now(UTC),
+        ),
+    ]
+    handler = EABriefingHandler()
+    result = handler.run(inbox_entries=inbox, pending_tasks=2)
+    assert result.state.inbox_received == 2
+    assert result.state.inbox_accepted == 2
+    assert result.state.pending_tasks == 2
+
+
+def test_briefing_counts_items_with_no_subject() -> None:
+    """Items with no subject are received but not accepted."""
+    inbox = [
+        InboxEntry(
+            subject="Good message",
+            body="Body",
+            from_address="a@e.com",
+        ),
+        InboxEntry(
+            subject="",
+            body="No subject line",
+            from_address="b@e.com",
+        ),
+        InboxEntry(
+            subject="  ",
+            body="Blank subject",
+            from_address="c@e.com",
+        ),
+    ]
+    handler = EABriefingHandler()
+    result = handler.run(inbox_entries=inbox)
+    assert result.state.inbox_received == 3
+    assert result.state.inbox_accepted == 1  # only "Good message"
+    assert len(handler._stderr) == 2  # two items with no subject
+
+
+# -----------------------------------------------------------------------
+# Milestone validity
+# -----------------------------------------------------------------------
+
+
+def test_validate_milestones_ok() -> None:
+    milestones = [
+        {"phase": "intake", "milestone": "received"},
+        {"phase": "plan", "milestone": "drafted"},
+    ]
+    _validate_milestones(milestones)  # should not raise
+
+
+def test_validate_milestones_invalid_phase() -> None:
+    with pytest.raises(ValueError):
+        _validate_milestones([{"phase": "invalid_phase"}])
+
+
+def test_all_phases_are_valid() -> None:
+    for phase in ALL_PHASES:
+        _validate_milestones([{"phase": phase, "milestone": "test"}])
+
+
+# -----------------------------------------------------------------------
+# BriefingResult fields
+# -----------------------------------------------------------------------
+
+
+def test_briefing_result_has_title() -> None:
+    handler = EABriefingHandler()
+    result = handler.run()
+    assert result.title == "EA Briefing — " + datetime.now(UTC).strftime("%Y-%m-%d")
+    assert "items_received" in result.artifact
+    assert "items_accepted" in result.artifact
+    assert "pending_tasks" in result.artifact
+    assert "generated_at" in result.artifact
+    assert "errors" in result.artifact
+
+
+# -----------------------------------------------------------------------
+# Phase compliance
+# -----------------------------------------------------------------------
+
+
+def test_milestones_only_use_valid_phases() -> None:
+    """All milestones from run() use phases from ALL_PHASES."""
+    handler = EABriefingHandler()
+    result = handler.run()
+    phases_used = {m["phase"] for m in result.milestones}
+    valid = set(ALL_PHASES)
+    assert phases_used <= valid

--- a/tests/unit/test_ea_task_service.py
+++ b/tests/unit/test_ea_task_service.py
@@ -1,0 +1,218 @@
+"""Tests for EA task service covering grant / deny-abandon / deny-alternate / timeout (P5-4 #84)."""
+
+import pytest
+
+from waywarden.services.approval_types import (
+    ApprovalAlreadyResolvedError,
+    DeniedAbandon,
+    DeniedAlternatePath,
+    Granted,
+    Timeout,
+)
+from waywarden.services.ea_task_service import (
+    ApprovalDecisionRequest,
+    CreateTaskRequest,
+    EATaskService,
+    RequestApprovalRequest,
+    TransitionTaskRequest,
+)
+
+# -----------------------------------------------------------------------
+# Task creation
+# -----------------------------------------------------------------------
+
+
+def test_create_task_emits_event() -> None:
+    svc = EATaskService()
+    task = svc.create_task(
+        CreateTaskRequest(
+            session_id="s1",
+            title="Test",
+            objective="Do stuff",
+            acceptance_criteria=("c1",),
+        )
+    )
+    assert task["state"] == "draft"
+    assert task["session_id"] == "s1"
+    events = svc.get_events()
+    assert len(events) == 1
+    assert events[0]["type"] == "run.progress"
+    assert events[0]["payload"]["phase"] == "task_created"
+
+
+# -----------------------------------------------------------------------
+# Task transitions
+# -----------------------------------------------------------------------
+
+
+def test_transition_draft_to_planning() -> None:
+    svc = EATaskService()
+    task = svc.create_task(CreateTaskRequest(session_id="s1", title="T", objective="O"))
+    result = svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="planning"))
+    assert result["state"] == "planning"
+    events = svc.get_events()
+    assert any(e["payload"]["phase"] == "task_transitioned" for e in events)
+
+
+def test_transition_executing_to_waiting_approval() -> None:
+    svc = EATaskService()
+    task = svc.create_task(CreateTaskRequest(session_id="s1", title="T", objective="O"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="planning"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="executing"))
+    result = svc.transition_task(
+        TransitionTaskRequest(task_id=task["id"], state="waiting_approval")
+    )
+    assert result["state"] == "waiting_approval"
+
+
+def test_transition_completed_is_forbidden() -> None:
+    svc = EATaskService()
+    task = svc.create_task(CreateTaskRequest(session_id="s1", title="T", objective="O"))
+    with pytest.raises(ValueError):
+        svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="completed"))
+
+
+def test_transition_nonexistent_task_raises() -> None:
+    svc = EATaskService()
+    with pytest.raises(KeyError):
+        svc.transition_task(TransitionTaskRequest(task_id="nonexistent", state="planning"))
+
+
+# -----------------------------------------------------------------------
+# Approval — grant
+# -----------------------------------------------------------------------
+
+
+def test_request_approval_emits_waiting_event() -> None:
+    svc = EATaskService()
+    task = svc.create_task(CreateTaskRequest(session_id="s1", title="T", objective="O"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="planning"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="executing"))
+    svc.request_approval(RequestApprovalRequest(task_id=task["id"]))
+    events = svc.get_events()
+    assert any(e["type"] == "run.approval_waiting" for e in events)
+
+
+def test_grant_approval_resolves_to_planning() -> None:
+    svc = EATaskService()
+    task = svc.create_task(CreateTaskRequest(session_id="s1", title="T", objective="O"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="planning"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="executing"))
+    svc.request_approval(RequestApprovalRequest(task_id=task["id"]))
+    result = svc.resolve_approval(ApprovalDecisionRequest(task_id=task["id"], decision=Granted()))
+    assert result["state"] == "granted"
+    events = svc.get_events()
+    assert any(e["type"] == "run.plan_ready" for e in events)
+
+
+# -----------------------------------------------------------------------
+# Approval — deny-abandon
+# -----------------------------------------------------------------------
+
+
+def test_deny_abandon_resolves_to_cancelled() -> None:
+    svc = EATaskService()
+    task = svc.create_task(CreateTaskRequest(session_id="s1", title="T", objective="O"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="planning"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="executing"))
+    svc.request_approval(RequestApprovalRequest(task_id=task["id"]))
+    result = svc.resolve_approval(
+        ApprovalDecisionRequest(task_id=task["id"], decision=DeniedAbandon(reason="skip"))
+    )
+    assert result["state"] == "denied_abandon"
+    events = svc.get_events()
+    assert any(e["type"] == "run.cancelled" for e in events)
+
+
+# -----------------------------------------------------------------------
+# Approval — deny-alternate
+# -----------------------------------------------------------------------
+
+
+def test_deny_alternate_path_resolves_with_note() -> None:
+    svc = EATaskService()
+    task = svc.create_task(CreateTaskRequest(session_id="s1", title="T", objective="O"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="planning"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="executing"))
+    svc.request_approval(RequestApprovalRequest(task_id=task["id"]))
+    result = svc.resolve_approval(
+        ApprovalDecisionRequest(
+            task_id=task["id"],
+            decision=DeniedAlternatePath(note="use-alternative"),
+        )
+    )
+    assert result["state"] == "denied_alternate_path"
+    events = svc.get_events()
+    # deny-alternate maps to run.progress
+    assert any(e["type"] == "run.progress" and "alternate_path" in e["payload"] for e in events)
+
+
+# -----------------------------------------------------------------------
+# Approval — timeout
+# -----------------------------------------------------------------------
+
+
+def test_timeout_resolves_to_cancelled() -> None:
+    svc = EATaskService()
+    task = svc.create_task(CreateTaskRequest(session_id="s1", title="T", objective="O"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="planning"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="executing"))
+    svc.request_approval(RequestApprovalRequest(task_id=task["id"]))
+    result = svc.resolve_approval(
+        ApprovalDecisionRequest(task_id=task["id"], decision=Timeout(retryable=True))
+    )
+    assert result["state"] == "timeout"
+    events = svc.get_events()
+    assert any(e["type"] == "run.cancelled" for e in events)
+
+
+# -----------------------------------------------------------------------
+# Already resolved approvals are rejected
+# -----------------------------------------------------------------------
+
+
+def test_resolve_already_resolved_approval_raises() -> None:
+    svc = EATaskService()
+    task = svc.create_task(CreateTaskRequest(session_id="s1", title="T", objective="O"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="planning"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="executing"))
+    svc.request_approval(RequestApprovalRequest(task_id=task["id"]))
+    svc.resolve_approval(ApprovalDecisionRequest(task_id=task["id"], decision=Granted()))
+    with pytest.raises(ApprovalAlreadyResolvedError):
+        svc.resolve_approval(
+            ApprovalDecisionRequest(task_id=task["id"], decision=DeniedAbandon(reason="double"))
+        )
+
+
+# -----------------------------------------------------------------------
+# Request approval on missing task raises
+# -----------------------------------------------------------------------
+
+
+def test_request_approval_on_missing_task_raises() -> None:
+    svc = EATaskService()
+    with pytest.raises(KeyError):
+        svc.request_approval(RequestApprovalRequest(task_id="nonexistent"))
+
+
+# -----------------------------------------------------------------------
+# RT-002 event assertions
+# -----------------------------------------------------------------------
+
+
+def test_full_event_stream_assertion() -> None:
+    """End-to-end: create -> planning -> executing -> approve -> grant -> transition."""
+    svc = EATaskService()
+    task = svc.create_task(CreateTaskRequest(session_id="s1", title="Build", objective="Ship it"))
+    assert task["state"] == "draft"
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="planning"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="executing"))
+    svc.request_approval(RequestApprovalRequest(task_id=task["id"]))
+    svc.resolve_approval(ApprovalDecisionRequest(task_id=task["id"], decision=Granted()))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="planning"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="executing"))
+    svc.transition_task(TransitionTaskRequest(task_id=task["id"], state="completed"))
+    events = svc.get_events()
+    assert any(e["type"] == "run.progress" for e in events)
+    assert any(e["type"] == "run.approval_waiting" for e in events)
+    assert any(e["type"] == "run.plan_ready" for e in events)


### PR DESCRIPTION
P5-5: EA routine — briefing

## Summary
Delivers the EA briefing routine as a profile-owned asset.

## What was implemented
- **EABriefingHandler** composes intake -> plan milestones
- Produces a dated briefing artifact with inbox stats
- Builds milestone stream per the orchestration catalog
- Milestone phase validation against ALL_PHASES
- Updated `assets/routines/ea-briefing/asset.yaml` with full metadata
- **8 unit tests** covering empty inbox, normal briefing, errors

## Dependencies
- P5-3 #83: EA profile hydration ✅
- P4-3 #66: Orchestration service (CLOSED) ✅

## Validation
- 84/84 tests passing across P5-1 through P5-5
- mypy: success
- ruff: all checks passed