### PR TITLE
P5-6: EA routine — scheduler (#86)

### DIFF
--- a/assets/routines/ea-scheduler/asset.yaml
+++ b/assets/routines/ea-scheduler/asset.yaml
@@ -1,0 +1,31 @@
+id: ea-scheduler
+kind: routine
+version: 1.0.0
+description: Schedules and dispatches EA tasks with explicit approval checkpoints.
+tags:
+  - ea
+  - scheduler
+required_providers: []
+milestones:
+  - phase: intake
+    names:
+      - received
+      - accepted
+  - phase: plan
+    names:
+      - drafted
+      - approval_requested
+      - ready
+  - phase: execute
+    names:
+      - tool_invoked
+      - waiting_approval
+emits_events:
+  - run.progress
+  - run.approval_waiting
+  - run.plan_ready
+  - run.failed
+  - run.cancelled
+profile_filter:
+  - op: include
+    tag: ea

--- a/src/waywarden/services/orchestration/scheduler.py
+++ b/src/waywarden/services/orchestration/scheduler.py
@@ -1,0 +1,158 @@
+"""EA scheduler routine handler.
+
+The EA scheduler picks tasks from a queue, schedules them, and
+dispatches with explicit approval checkpoints.  It uses the EA
+task service (P5-4) for task creation and approval.
+
+Canonical references:
+    - ADR 0005 (approval model)
+    - ADR 0007 (good/bad patterns)
+    - P5-3 #83 (EA profile)
+    - P5-4 #84 (EA task service)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from waywarden.services.approval_types import (
+    ApprovalDecision,
+    DeniedAbandon,
+    DeniedAlternatePath,
+    Granted,
+)
+from waywarden.services.ea_task_service import (
+    ApprovalDecisionRequest,
+    CreateTaskRequest,
+    EATaskService,
+    RequestApprovalRequest,
+    TransitionTaskRequest,
+)
+
+
+@dataclass(slots=True)
+class ScheduledTask:
+    """A task in the scheduling queue."""
+
+    title: str
+    objective: str
+    due_at: str | None = None
+    status: str = "queued"
+
+
+@dataclass(slots=True)
+class ScheduleResult:
+    """Result of running the scheduler."""
+
+    tasks_processed: int = 0
+    tasks_approved: int = 0
+    tasks_denied: int = 0
+    tasks_rescheduled: int = 0
+    decisions: list[dict[str, Any]] = field(default_factory=list)
+
+
+class EASchedulerHandler:
+    """Schedules and dispatches EA tasks with approval checkpoints.
+
+    This handler is synchronous for testability.  In production it
+    would be driven by the orchestration service milestone engine.
+    """
+
+    def __init__(self, task_service: EATaskService | None = None) -> None:
+        self.task_service = task_service or EATaskService()
+
+    def run(
+        self,
+        tasks: list[ScheduledTask],
+        decisions: dict[str, ApprovalDecision] | None = None,
+    ) -> ScheduleResult:
+        """Execute the scheduler against a list of queued tasks.
+
+        Args:
+            tasks: Tasks to schedule and dispatch.
+            decisions: Map from ScheduledTask title to the approval
+                decision to apply.  If not supplied, all tasks are
+                auto-granted.
+
+        Returns:
+            A >>ScheduleResult`` summarising the scheduling run.
+        """
+        result = ScheduleResult()
+        decisions = decisions or {}
+        for idx, stask in enumerate(tasks, start=1):
+            # 1. Create the task
+            task = self.task_service.create_task(
+                CreateTaskRequest(
+                    session_id="scheduler-sess",
+                    title=stask.title,
+                    objective=stask.objective,
+                )
+            )
+            task_id = task["id"]
+
+            # 2. Transition to executing
+            self.task_service.transition_task(
+                TransitionTaskRequest(
+                    task_id=task_id, state="planning"
+                )
+            )
+            self.task_service.transition_task(
+                TransitionTaskRequest(
+                    task_id=task_id, state="executing"
+                )
+            )
+
+            # 3. Request approval checkpoint
+            self.task_service.request_approval(
+                RequestApprovalRequest(task_id=task_id)
+            )
+
+            # 4. Apply decision — look up by title first, then index
+            decision = decisions.get(stask.title)
+            if decision is None:
+                decision = decisions.get(str(idx))
+            if decision is None:
+                decision = Granted()
+
+            self.task_service.resolve_approval(
+                ApprovalDecisionRequest(
+                    task_id=task_id,
+                    decision=decision,
+                )
+            )
+
+            result.tasks_processed += 1
+
+            if isinstance(decision, Granted):
+                result.tasks_approved += 1
+                self.task_service.transition_task(
+                    TransitionTaskRequest(
+                        task_id=task_id, state="planning"
+                    )
+                )
+                self.task_service.transition_task(
+                    TransitionTaskRequest(
+                        task_id=task_id, state="executing"
+                    )
+                )
+                self.task_service.transition_task(
+                    TransitionTaskRequest(
+                        task_id=task_id, state="completed"
+                    )
+                )
+            elif isinstance(decision, DeniedAbandon):
+                result.tasks_denied += 1
+            elif isinstance(decision, DeniedAlternatePath):
+                result.tasks_rescheduled += 1
+                self.task_service.transition_task(
+                    TransitionTaskRequest(
+                        task_id=task_id, state="planning"
+                    )
+                )
+            result.decisions.append({
+                "task_id": task_id,
+                "decision": type(decision).__name__,
+            })
+
+        return result

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -1,0 +1,110 @@
+"""Tests for EA scheduler routine (P5-6 #86)."""
+
+
+from waywarden.services.approval_types import (
+    DeniedAbandon,
+    DeniedAlternatePath,
+    Granted,
+)
+from waywarden.services.ea_task_service import EATaskService
+from waywarden.services.orchestration.scheduler import (
+    EASchedulerHandler,
+    ScheduledTask,
+    ScheduleResult,
+)
+
+# -----------------------------------------------------------------------
+# Schedule with auto-grant
+# -----------------------------------------------------------------------
+
+
+def test_schedule_auto_grant() -> None:
+    """With no explicit response, all tasks are granted."""
+    tasks = [
+        ScheduledTask(title="Task 1", objective="Obj 1"),
+        ScheduledTask(title="Task 2", objective="Obj 2"),
+    ]
+    svc = EATaskService()
+    handler = EASchedulerHandler(task_service=svc)
+    result = handler.run(tasks)
+    assert result.tasks_processed == 2
+    assert result.tasks_approved == 2
+    assert result.tasks_denied == 0
+    assert result.tasks_rescheduled == 0
+
+
+def test_schedule_respects_response_map() -> None:
+    """Explicit deny-abandon should count as denied."""
+    tasks = [ScheduledTask(title="my-task", objective="O")]
+    svc = EATaskService()
+    handler = EASchedulerHandler(task_service=svc)
+    decision = handler.run(
+        tasks,
+        decisions={"my-task": DeniedAbandon(reason="nope")},
+    )
+    assert decision.tasks_processed == 1
+    assert decision.tasks_approved == 0
+    assert decision.tasks_denied == 1
+
+
+def test_schedule_respects_deny_alternate() -> None:
+    """Explicit deny-alternate should count as rescheduled."""
+    tasks = [ScheduledTask(title="a", objective="O")]
+    svc = EATaskService()
+    handler = EASchedulerHandler(task_service=svc)
+    decision = handler.run(
+        tasks,
+        decisions={"a": DeniedAlternatePath(note="alt")},
+    )
+    assert decision.tasks_rescheduled == 1
+
+
+def test_schedule_empty_list() -> None:
+    """Scheduler with no tasks should return zero."""
+    handler = EASchedulerHandler()
+    result = handler.run([])
+    assert result.tasks_processed == 0
+    assert result.tasks_approved == 0
+
+
+def test_schedule_multiple_mixed_outcomes() -> None:
+    """Mix of grant, deny-abandon, and deny-alternate."""
+    tasks = [
+        ScheduledTask(title="grant", objective="O"),
+        ScheduledTask(title="deny", objective="O"),
+        ScheduledTask(title="resched", objective="O"),
+    ]
+    svc = EATaskService()
+    handler = EASchedulerHandler(task_service=svc)
+    result = handler.run(
+        tasks,
+        decisions={
+            "grant": Granted(),
+            "deny": DeniedAbandon(reason="no"),
+            "resched": DeniedAlternatePath(note="try-alt"),
+        },
+    )
+    assert result.tasks_processed == 3
+    assert result.tasks_approved == 1
+    assert result.tasks_denied == 1
+    assert result.tasks_rescheduled == 1
+
+
+def test_schedule_decisions_recorded() -> None:
+    """Every task should have a decision record."""
+    svc = EATaskService()
+    handler = EASchedulerHandler(task_service=svc)
+    result = handler.run(
+        [ScheduledTask(title="x", objective="O")],
+    )
+    assert len(result.decisions) == 1
+    assert result.decisions[0]["decision"] == "Granted"
+    assert "task_id" in result.decisions[0]
+
+
+def test_schedule_returns_schedule_result_type() -> None:
+    """Return value should be a ScheduleResult."""
+    svc = EATaskService()
+    handler = EASchedulerHandler(task_service=svc)
+    result = handler.run([])
+    assert isinstance(result, ScheduleResult)


### PR DESCRIPTION
P5-6: EA routine — scheduler

## Summary
Delivers the EA scheduler routine with approval checkpoints.

## What was implemented
- **EASchedulerHandler** loops tasks through create -> execute -> approve
- **Decisions mapped to lifecycle**: grant→completed, deny-abandon→denied, deny-alternate→rescheduled
- `assets/routines/ea-scheduler/asset.yaml` with full P5-1 metadata
- **7 unit tests** covering auto-grant, explicit decisions, mixed outcomes

## Dependencies
- P5-3 #83 ✅, P5-4 #84 ✅, #66 (P4-3) ✅

## Validation
- 91/91 tests passing
- mypy: success
- ruff: all checks passed