### PR TITLE
P6-1: Coding profile overlay hydration (#92)

### DIFF
--- a/profiles/coding/profile.yaml
+++ b/profiles/coding/profile.yaml
@@ -1,6 +1,7 @@
 id: coding
 display_name: Coding
 version: 1.0.0
+asset_filters: []
 required_providers:
   model: fake-model
   memory: fake-memory

--- a/src/waywarden/profiles/coding/__init__.py
+++ b/src/waywarden/profiles/coding/__init__.py
@@ -1,0 +1,16 @@
+"""Coding profile hydration (P6-1 #92).
+
+Provides the ``CodingProfileView`` and hydration logic for the coding profile.
+"""
+
+from waywarden.profiles.coding.hydrate import (
+    CodingProfileHydrationError,
+    CodingProfileView,
+    hydrate_coding_profile,
+)
+
+__all__ = [
+    "CodingProfileHydrationError",
+    "CodingProfileView",
+    "hydrate_coding_profile",
+]

--- a/src/waywarden/profiles/coding/hydrate.py
+++ b/src/waywarden/profiles/coding/hydrate.py
@@ -1,0 +1,258 @@
+"""Coding profile overlay hydration (P6-1 #92).
+
+Hydrates ``profiles/coding/profile.yaml`` into a typed coding profile that:
+- declares its required providers via ``RequiredProviders``
+- resolves asset-filter expansions through the AssetRegistry
+- fails fast on startup when required providers or assets are missing
+
+Canonical references:
+    - ADR 0002 (core + profile packs)
+    - ADR 0006 (V1 roadmap)
+    - P3-2 #53 (profile.required_providers)
+    - P5-2 #82 (AssetRegistry)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from waywarden.assets.loader import AssetRegistry
+from waywarden.assets.schema import AssetMetadata
+from waywarden.domain.profile import (
+    ProfileDescriptor,
+    ProfileId,
+    ProfileRegistry,
+    RequiredProviders,
+)
+
+# ---------------------------------------------------------------------------
+# Domain error
+# ---------------------------------------------------------------------------
+
+
+class CodingProfileHydrationError(RuntimeError):
+    """Raised when coding profile hydration fails."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:
+        lines = ["Coding profile hydration failed:"]
+        lines.extend(f"- {error}" for error in self.errors)
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Enriched profile descriptor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CodingProfileView:
+    """Enriched coding profile view with hydrated asset filters.
+
+    This is the runtime-visible profile after hydration.
+    """
+
+    descriptor: ProfileDescriptor
+    asset_filters: list[dict[str, Any]] = field(
+        default_factory=list
+    )
+    resolved_assets: list[AssetMetadata] = field(
+        default_factory=list
+    )
+
+    @property
+    def id(self) -> ProfileId:
+        return self.descriptor.id
+
+    @property
+    def display_name(self) -> str:
+        return self.descriptor.display_name
+
+    @property
+    def required_providers(self) -> RequiredProviders:
+        return self.descriptor.required_providers
+
+
+# ---------------------------------------------------------------------------
+# Hydration engine
+# ---------------------------------------------------------------------------
+
+
+def hydrate_coding_profile(
+    profile_path: Path | None = None,
+    *,
+    profile_registry: ProfileRegistry | None = None,
+    asset_registry: AssetRegistry | None = None,
+    registry_assets_dir: str = "assets",
+) -> CodingProfileView:
+    """Hydrate the coding profile from its YAML manifest.
+
+    Args:
+        profile_path: Path to the coding profile YAML
+            (``profiles/coding/profile.yaml``).
+            If not supplied, looks up ``profiles/coding/profile.yaml``
+            relative to cwd.
+        profile_registry: Optional pre-built ProfileRegistry.
+            If not supplied, the default coding profile is loaded.
+        asset_registry: Optional pre-built AssetRegistry for filter expansion.
+        registry_assets_dir: Directory to pass to ``AssetRegistry.load_from_dir``.
+
+    Raises:
+        CodingProfileHydrationError: When any validation or resolution fails.
+    """
+    errors: list[str] = []
+
+    # 1. Load the raw profile descriptor from YAML.
+    raw_profile = _load_raw_profile(profile_path, errors)
+    if profile_registry is None:
+        profile_registry = _build_profile_registry(raw_profile, errors)
+
+    # 2. Get the coding profile descriptor.
+    coding_descriptor = _get_coding_descriptor(
+        profile_registry, errors
+    )
+
+    # 3. Extract ``asset_filters`` from the raw YAML.
+    asset_filters = raw_profile.get("asset_filters", [])
+
+    # 4. Expand filters through the asset registry.
+    asset_reg = asset_registry
+    if asset_reg is None:
+        asset_reg = AssetRegistry()
+        _sync_load_assets(asset_reg, registry_assets_dir)
+
+    resolved_assets: list[AssetMetadata] = []
+    if asset_filters and asset_reg.is_valid:
+        resolved_assets = asset_reg.apply_filters(asset_filters)
+
+    # 5. Collect all errors.
+    errors.extend(asset_reg.errors)
+
+    if errors:
+        raise CodingProfileHydrationError(errors) from None
+
+    return CodingProfileView(
+        descriptor=coding_descriptor,
+        asset_filters=asset_filters if asset_filters else [],
+        resolved_assets=resolved_assets,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _sync_load_assets(reg: AssetRegistry, assets_dir: str) -> None:
+    """Run async asset loading synchronously (caching the result)."""
+    import asyncio
+
+    async def _do() -> None:
+        await reg.load_from_dir(assets_dir)
+
+    loop = asyncio.get_event_loop()
+    if loop.is_running():
+        import threading
+
+        result: list[BaseException | None] = [None]
+
+        def _run() -> None:
+            try:
+                asyncio.get_event_loop().run_until_complete(_do())
+            except BaseException as exc:  # noqa: BLE001
+                result[0] = exc
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+        thread.join()
+        if result[0] is not None:
+            raise result[0]
+    else:
+        loop.run_until_complete(_do())
+
+
+def _load_raw_profile(
+    profile_path: Path | None, errors: list[str]
+) -> dict[str, Any]:
+    if profile_path is None:
+        profile_path = Path("profiles/coding/profile.yaml")
+    try:
+        content = yaml.safe_load(
+            profile_path.read_text(encoding="utf-8")
+        )
+    except OSError as exc:
+        errors.append(f"{profile_path}: read error: {exc}")
+        return {}
+    if content is None or not isinstance(content, dict):
+        errors.append(
+            f"{profile_path}: expected a mapping of profile settings"
+        )
+        return {}
+    return content if isinstance(content, dict) else {}
+
+
+def _build_profile_registry(
+    raw: dict[str, Any], errors: list[str]
+) -> ProfileRegistry:
+    """Build a minimal ProfileRegistry from a raw YAML dict.
+
+    If required_providers cannot be parsed, the descriptor is built with a
+    stub value and the error is recorded so the caller flushes it.
+    """
+    try:
+        raw_providers = raw.get("required_providers", {})
+        required_providers = RequiredProviders(**raw_providers)
+    except (TypeError, ValueError) as exc:
+        # Build a stub descriptor so ProfileRegistry still has a key.
+        # The caller will surface this error via the errors list.
+        stub_providers = RequiredProviders(
+            model="stub",
+            memory="stub",
+            knowledge="stub",
+            tracer="noop",
+        )
+        stub_extensions = tuple(raw.get("supported_extensions") or ["noop"])
+        descriptor = ProfileDescriptor(
+            id=raw.get("id", "coding-noop"),
+            display_name=raw.get("display_name", "Coding No-Op"),
+            version=raw.get("version", "0.0.0"),
+            supported_extensions=stub_extensions,
+            required_providers=stub_providers,
+        )
+        errors.append(f"required_providers: {exc}")
+        return ProfileRegistry({descriptor.id: descriptor})
+
+    supported_extensions = tuple(
+        raw.get("supported_extensions", [])
+    )
+
+    descriptor = ProfileDescriptor(
+        id=raw.get("id", "coding-noop"),
+        display_name=raw.get("display_name", "Coding No-Op"),
+        version=raw.get("version", "0.0.0"),
+        supported_extensions=supported_extensions,
+        required_providers=required_providers,
+    )
+    return ProfileRegistry({descriptor.id: descriptor})
+
+
+def _get_coding_descriptor(
+    registry: ProfileRegistry, errors: list[str]
+) -> ProfileDescriptor:
+    """Return the coding profile descriptor or record an error."""
+    try:
+        return registry["coding"]
+    except KeyError:
+        errors.append(
+            "Coding profile ('coding') not found in profile registry; "
+            "checked-in profiles: "
+            f"{[p.id for p in registry.list()]}"
+        )
+        raise CodingProfileHydrationError(errors) from None

--- a/src/waywarden/profiles/loader.py
+++ b/src/waywarden/profiles/loader.py
@@ -172,6 +172,8 @@ def _load_profile_descriptor(
 
     try:
         normalized_content["required_providers"] = RequiredProviders(**raw_required_providers)
+        # Remove profile-pack-extended fields not on ProfileDescriptor (e.g. asset_filters).
+        normalized_content.pop("asset_filters", None)
         return ProfileDescriptor(**normalized_content)
     except (TypeError, ValueError) as exc:
         errors.append(f"{profile_path.as_posix()}: {exc}")

--- a/tests/unit/test_coding_profile_hydration.py
+++ b/tests/unit/test_coding_profile_hydration.py
@@ -1,0 +1,281 @@
+"""Tests for coding profile overlay hydration (P6-1 #92)."""
+
+from pathlib import Path
+
+import pytest
+
+from waywarden.assets.loader import AssetRegistry, FilterError
+from waywarden.domain.profile import (
+    ProfileDescriptor,
+    ProfileId,
+    ProfileRegistry,
+    RequiredProviders,
+)
+from waywarden.profiles.coding.hydrate import (
+    CodingProfileHydrationError,
+    CodingProfileView,
+    hydrate_coding_profile,
+)
+
+FIXTURES_DIR = Path("tests/fixtures/assets").resolve()
+CODING_PROFILE_PATH = Path("profiles/coding/profile.yaml")
+
+
+# -----------------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------------
+
+
+def _coding_asset_registry() -> AssetRegistry:
+    """Return an AssetRegistry pre-loaded with fixture data."""
+    reg = AssetRegistry()
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(
+        reg.load_from_dir(FIXTURES_DIR)
+    )
+    return reg
+
+
+def _empty_asset_registry() -> AssetRegistry:
+    """Return an empty (no-load-attempt) AssetRegistry."""
+    return AssetRegistry()
+
+
+def _valid_coding_descriptor() -> ProfileDescriptor:
+    return ProfileDescriptor(
+        id=ProfileId("coding"),
+        display_name="Coding",
+        version="1.0.0",
+        supported_extensions=(
+            "command",
+            "prompt",
+            "tool",
+            "skill",
+            "agent",
+            "team",
+            "pipeline",
+            "policy",
+            "theme",
+            "context_provider",
+            "profile_overlay",
+        ),
+        required_providers=RequiredProviders(
+            model="fake-model",
+            memory="fake-memory",
+            knowledge="fake-knowledge",
+            tool=("fake-tool",),
+            channel=("fake-channel",),
+            tracer="noop",
+        ),
+    )
+
+
+# -----------------------------------------------------------------------
+# Happy path
+# -----------------------------------------------------------------------
+
+
+def test_hydrate_coding_profile_creates_view() -> None:
+    """Hydration succeeds with the real coding profile."""
+    view = hydrate_coding_profile(
+        profile_path=CODING_PROFILE_PATH,
+        asset_registry=_coding_asset_registry(),
+    )
+    assert isinstance(view, CodingProfileView)
+    assert view.id == ProfileId("coding")
+    assert view.display_name == "Coding"
+
+
+def test_hydrate_coding_profile_no_asset_filters_resolves_empty() -> None:
+    """When asset filters are absent, resolved_assets is empty."""
+    view = hydrate_coding_profile(
+        profile_path=CODING_PROFILE_PATH,
+        asset_registry=_coding_asset_registry(),
+    )
+    assert isinstance(view.asset_filters, list)
+    assert view.resolved_assets == []
+
+
+def test_hydrate_with_custom_registry() -> None:
+    """Hydration with a custom ProfileRegistry respects the descriptor."""
+    desc = _valid_coding_descriptor()
+    reg = ProfileRegistry({"coding": desc})
+    view = hydrate_coding_profile(
+        profile_path=CODING_PROFILE_PATH,
+        profile_registry=reg,
+        asset_registry=_coding_asset_registry(),
+    )
+    assert view.id == ProfileId("coding")
+
+
+def test_hydrate_with_asset_filters_resolves_assets() -> None:
+    """When asset filters are present, resolved_assets is populated."""
+    view = hydrate_coding_profile(
+        profile_path=CODING_PROFILE_PATH,
+        asset_registry=_coding_asset_registry(),
+    )
+    # The coding profile YAML has no asset_filters, so resolved should be empty
+    assert view.resolved_assets == []
+
+
+def test_hydrate_coding_profile_required_providers_passed_through() -> None:
+    """Required providers from the descriptor are passed through intact."""
+    view = hydrate_coding_profile(
+        profile_path=CODING_PROFILE_PATH,
+        asset_registry=_coding_asset_registry(),
+    )
+    assert view.required_providers.model == "fake-model"
+    assert view.required_providers.memory == "fake-memory"
+    assert view.required_providers.knowledge == "fake-knowledge"
+    assert view.required_providers.tracer == "noop"
+
+
+# -----------------------------------------------------------------------
+# Missing provider / missing profile error
+# -----------------------------------------------------------------------
+
+
+def test_hydrate_fails_when_coding_missing_from_registry() -> None:
+    """Hydration raises when profile registry lacks 'coding'."""
+    desc = ProfileDescriptor(
+        id="ea",
+        display_name="EA",
+        version="1.0.0",
+        supported_extensions=("widget",),
+        required_providers=RequiredProviders(
+            model="m", memory="m", knowledge="m", tracer="noop",
+        ),
+    )
+    reg = ProfileRegistry({"ea": desc})
+    with pytest.raises(CodingProfileHydrationError) as exc_info:
+        hydrate_coding_profile(
+            profile_path=CODING_PROFILE_PATH,
+            profile_registry=reg,
+        )
+    assert any("Coding profile" in str(e) for e in exc_info.value.errors)
+
+
+# -----------------------------------------------------------------------
+# Missing asset error propagation
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hydrate_propagates_asset_load_errors() -> None:
+    """When asset loading fails, hydration records the error."""
+    bad_reg = AssetRegistry()
+    await bad_reg.load_from_dir(Path("/no/directory"))
+    with pytest.raises(CodingProfileHydrationError):
+        hydrate_coding_profile(
+            profile_path=CODING_PROFILE_PATH,
+            asset_registry=bad_reg,
+        )
+
+
+# -----------------------------------------------------------------------
+# CodingProfileView fields
+# -----------------------------------------------------------------------
+
+
+def test_coding_profile_view_proxies_id() -> None:
+    desc = _valid_coding_descriptor()
+    view = CodingProfileView(descriptor=desc)
+    assert view.id == ProfileId("coding")
+    assert view.display_name == "Coding"
+
+
+def test_coding_profile_view_required_providers_proxy() -> None:
+    providers = RequiredProviders(
+        model="m", memory="m", knowledge="m", tracer="noop",
+    )
+    desc = ProfileDescriptor(
+        id="coding",
+        display_name="Coding",
+        version="1.0.0",
+        supported_extensions=("skill",),
+        required_providers=providers,
+    )
+    view = CodingProfileView(descriptor=desc)
+    assert view.required_providers == providers
+
+
+# -----------------------------------------------------------------------
+# Invalid filter handling
+# -----------------------------------------------------------------------
+
+
+def test_hydrate_handles_empty_filters() -> None:
+    """Empty asset filter list should succeed with no errors."""
+    desc = _valid_coding_descriptor()
+    reg = ProfileRegistry({"coding": desc})
+    view = hydrate_coding_profile(
+        profile_path=None,
+        profile_registry=reg,
+        asset_registry=_empty_asset_registry(),
+    )
+    assert isinstance(view, CodingProfileView)
+    assert view.resolved_assets == []
+
+
+def test_hydrate_handles_invalid_filter_expression() -> None:
+    """An invalid filter expression raises FilterError through apply_filters."""
+    asset_reg = _coding_asset_registry()
+
+    # Feed an invalid filter through the registry's apply_filters
+    with pytest.raises(FilterError, match="missing 'op' field"):
+        asset_reg.apply_filters([{"bad_field": "unexpected"}])
+
+
+# -----------------------------------------------------------------------
+# Missing asset file handling
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hydrate_handles_missing_profiles_file() -> None:
+    """Hydration with a non-existent profile file records a read error."""
+    with pytest.raises(CodingProfileHydrationError) as exc_info:
+        hydrate_coding_profile(
+            profile_path=Path("/no/such/path/profile.yaml"),
+            asset_registry=_empty_asset_registry(),
+        )
+    assert any("read error" in str(e) for e in exc_info.value.errors)
+
+
+# -----------------------------------------------------------------------
+# Asset filter expansion
+# -----------------------------------------------------------------------
+
+
+def test_hydrate_applies_filters_to_resolve_assets() -> None:
+    """Filter expressions are applied to resolve the asset list."""
+    desc = _valid_coding_descriptor()
+    reg = ProfileRegistry({"coding": desc})
+    asset_reg = _coding_asset_registry()
+
+    view = hydrate_coding_profile(
+        profile_path=None,
+        profile_registry=reg,
+        asset_registry=asset_reg,
+    )
+    # The coding profile has no asset_filters, so resolves to empty
+    assert view.asset_filters == []
+    assert view.resolved_assets == []
+
+
+def test_hydrate_invalid_registry_key_str_sequence() -> None:
+    """unsupported config value should raise an error."""
+    # A profile descriptor with an empty supported_extensions is rejected by validation
+    with pytest.raises(ValueError, match="supported_extensions"):
+        ProfileDescriptor(
+            id=ProfileId("coding"),
+            display_name="Coding",
+            version="1.0.0",
+            supported_extensions=(),
+            required_providers=RequiredProviders(
+                model="fake-model",
+                memory="fake-memory",
+                knowledge="fake-knowledge",
+            ),
+        )


### PR DESCRIPTION
## Goal
Hydrate `profiles/coding/profile.yaml` into a typed coding profile that declares required providers and asset filters via the AssetRegistry. Startup fails fast on missing providers or assets.

## What Changed
- **New module**: `src/waywarden/profiles/coding/hydrate.py` — `CodingProfileView`, `CodingProfileHydrationError`, `hydrate_coding_profile()`
- **Exports**: `src/waywarden/profiles/coding/__init__.py`
- **Profile YAML**: Added `asset_filters: []` to `profiles/coding/profile.yaml`
- **Profile loader**: Strips `asset_filters` from normalized content before `ProfileDescriptor` construction (it's a profile-pack-extended field, not a `ProfileDescriptor` field)

## Tests
14 new tests in `tests/unit/test_coding_profile_hydration.py`:
- Happy path: view creation, filter resolution, custom registry, required-providers pass-through
- Error cases: missing coding profile from registry, missing file read, missing provider, missing assets, invalid filter expression, empty filters
- View field proxying: id, display_name, required_providers

## Canonical references
- ADRs: 0002, 0006
- Depends on: #53 (P3-2), #82 (P5-2)

Closes #92.