### PR TITLE
P6-2: Repo-aware context provider (#93)

### DIFF
--- a/src/waywarden/domain/context_provider.py
+++ b/src/waywarden/domain/context_provider.py
@@ -1,0 +1,246 @@
+"""Repo-aware context provider for coding sessions.
+
+Provides git metadata, filesystem excerpts, and artifact-link context to
+the context pipeline. Provider-neutral; no SDK types leak into the domain
+layer.
+
+Canonical references:
+    - ADR 0001 (provider-neutral boundary)
+    - ADR 0003 (memory vs knowledge — context is neither)
+    - ADR 0011 (harness boundaries)
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ContextProvider(Protocol):
+    """Protocol for providers that inject context into prompt envelopes."""
+
+    async def provide(self, session_id: str, user_input: str) -> str:
+        """Return context text to prepend to a prompt envelope.
+
+        Args:
+            session_id: The current session identifier.
+            user_input: The user message being answered.
+
+        Returns:
+            A string of context metadata to inject into the system prompt.
+        """
+
+
+# ---------------------------------------------------------------------------
+# Value types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ContextFragment:
+    """A single block of context text with metadata."""
+
+    heading: str
+    content: str
+
+    def render(self) -> str:
+        """Render this fragment in a human-readable format."""
+        return f"## {self.heading}\n{self.content}"
+
+
+# ---------------------------------------------------------------------------
+# Secret-scrubbing
+# ---------------------------------------------------------------------------
+
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?:api[_-]?key|token|secret|password)\s*[=:]\s*\S+", re.I),
+    re.compile(r"-----BEGIN\s+(?:RSA|EC|DSA)\s+PRIVATE\s+KEY-----", re.I),
+    re.compile(
+        r"(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}", re.I
+    ),
+)
+
+
+def scrub_secrets(text: str) -> str:
+    """Redact likely secrets from context text.
+
+    Args:
+        text: Raw context text that may contain sensitive values.
+
+    Returns:
+        Text with secret patterns replaced by ``[REDACTED]``.
+    """
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub("[REDACTED]", text)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Path-safety
+# ---------------------------------------------------------------------------
+
+def _is_safe_path(repo_root: Path, path: Path) -> bool:
+    """Check that *path* resolves inside *repo_root* (no symlinks escaping)."""
+    try:
+        return path.resolve().is_relative_to(repo_root.resolve())
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Concrete implementation
+# ---------------------------------------------------------------------------
+
+DEFAULT_MAX_FILE_SIZE = 8192  # bytes — truncate files beyond this size
+
+
+class RepoContextProvider:
+    """Provider that feeds git + filesystem + artifact context into prompts.
+
+    Args:
+        repo_root: The repository root path.
+        max_file_size: Maximum bytes per file excerpt (default 8192).
+    """
+
+    def __init__(
+        self,
+        repo_root: Path | str,
+        *,
+        max_file_size: int = DEFAULT_MAX_FILE_SIZE,
+    ) -> None:
+        self._repo_root = Path(repo_root).resolve()
+        self._max_file_size = max_file_size
+
+    @property
+    def repo_root(self) -> Path:
+        """Read-only access to the repository root."""
+        return self._repo_root
+
+    # ---- public API ----------------------------------------------------
+
+    async def provide(self, session_id: str, user_input: str) -> str:
+        """Assemble context fragments for the given session and input.
+
+        Returns a single string containing all context sections, each
+        prefixed by a heading.
+        """
+        fragments: list[ContextFragment] = []
+
+        try:
+            fragments.append(self._git_status_fragment())
+        except subprocess.CalledProcessError:
+            pass  # Not a git repo — skip git section.
+        except OSError:
+            pass  # Permissions issue — skip.
+
+        fragments.append(self._filesystem_excerpts_fragment())
+        fragments.append(self._artifact_references_fragment(session_id))
+
+        rendered = "\n\n".join(f.render() for f in fragments)
+        return scrub_secrets(rendered)
+
+    # ---- fragment builders ---------------------------------------------
+
+    def _git_status_fragment(self) -> ContextFragment:
+        """Capture git status, branch, and uncommitted changes."""
+        lines: list[str] = []
+
+        # Branch
+        try:
+            branch = subprocess.check_output(
+                ["git", "-C", str(self._repo_root), "branch", "--show-current"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            lines.append(f"branch: {branch or '(detached)'}")
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            lines.append("branch: (detached or not a git repo)")
+
+        # Status
+        try:
+            status = subprocess.check_output(
+                ["git", "-C", str(self._repo_root), "status", "--porcelain"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            if status:
+                lines.extend(status.splitlines())
+            else:
+                lines.append("working tree: clean")
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            lines.append("working tree: (unable to read)")
+
+        return ContextFragment(
+            heading="Git context",
+            content="\n".join(lines),
+        )
+
+    def _filesystem_excerpts_fragment(self) -> ContextFragment:
+        """List relevant files and include short excerpts."""
+        lines: list[str] = []
+
+        try:
+            tracked_files = subprocess.check_output(
+                ["git", "-C", str(self._repo_root), "ls-files"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip().splitlines()
+
+            # Only show first 20 tracked files to avoid dump.
+            for rel_path in tracked_files[:20]:
+                file_path = self._repo_root / rel_path
+                if not file_path.is_file():
+                    continue
+                if not _is_safe_path(self._repo_root, file_path):
+                    continue
+                content = self._read_file_excerpt(file_path)
+                lines.append(f"- {rel_path} ({len(content)} bytes)")
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            lines.append("(no tracked files)")
+
+        return ContextFragment(
+            heading="Relevant files",
+            content="\n".join(lines) or "(none)",
+        )
+
+    def _artifact_references_fragment(self, session_id: str) -> ContextFragment:
+        """Reference any known artifacts for this session."""
+        lines: list[str] = [f"session: {session_id}"]
+
+        # List any artifact-like directories (plans, diffs, check results)
+        for subdir in ("plans", "artifacts", "checks"):
+            dir_path = self._repo_root / subdir
+            if dir_path.is_dir():
+                child_files = sorted(dir_path.iterdir())
+                for child in child_files[:10]:
+                    lines.append(f"artifact: {subdir}/{child.name}")
+
+        return ContextFragment(
+            heading="Artifact references",
+            content="\n".join(lines),
+        )
+
+    def _read_file_excerpt(self, file_path: Path) -> str:
+        """Read up to ``max_file_size`` bytes from *file_path*."""
+        if not file_path.is_file():
+            return "(file not found)"
+        if not _is_safe_path(self._repo_root, file_path):
+            return "(access denied)"
+        try:
+            data = file_path.read_bytes()
+            if len(data) > self._max_file_size:
+                truncated = data[: self._max_file_size]
+                return truncated.decode("utf-8", errors="replace") + (
+                    "\n... [truncated, exceeded max file size]"
+                )
+            return data.decode("utf-8", errors="replace")
+        except OSError:
+            return "(unable to read)"

--- a/tests/domain/test_context_provider.py
+++ b/tests/domain/test_context_provider.py
@@ -1,0 +1,300 @@
+"""Tests for the repo-aware context provider (P6-2 #93)."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from waywarden.domain.context_provider import (
+    ContextFragment,
+    RepoContextProvider,
+    _is_safe_path,
+    scrub_secrets,
+)
+
+FIXTURES_DIR = Path("tests/fixtures").resolve()
+SAMPLE_REPO_DIR = Path("tests/fixtures/sample_repo").resolve()
+
+
+# -----------------------------------------------------------------------
+# ContextFragment rendering
+# -----------------------------------------------------------------------
+
+
+def test_fragment_render() -> None:
+    f = ContextFragment(heading="Git", content="branch: main")
+    assert f.render() == "## Git\nbranch: main"
+
+
+# -----------------------------------------------------------------------
+# Secret scrubbing
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("api_key: abc123", "[REDACTED]"),
+        ("token = xyz789", "[REDACTED]"),
+        ("secret: mysecret", "[REDACTED]"),
+        ("password: hunter2", "[REDACTED]"),
+        ("no secrets here", "no secrets here"),
+        (
+            "-----BEGIN RSA PRIVATE KEY-----",
+            "[REDACTED]",
+        ),
+        (
+            "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
+            "[REDACTED]",
+        ),
+    ],
+)
+def test_scrub_secrets(text: str, expected: str) -> None:
+    assert scrub_secrets(text) == expected
+
+
+# -----------------------------------------------------------------------
+# Path-safety
+# -----------------------------------------------------------------------
+
+
+def test_is_safe_path_inside_repo() -> None:
+    root = Path("/tmp/repo")
+    child = Path("/tmp/repo/src/file.txt")
+    assert _is_safe_path(root, child)
+
+
+def test_is_safe_path_sibling_outside() -> None:
+    root = Path("/tmp/repo")
+    sibling = Path("/tmp/other/file.txt")
+    assert not _is_safe_path(root, sibling)
+
+
+def test_is_safe_path_parent_escape() -> None:
+    root = Path("/tmp/repo")
+    escape = Path("/tmp/repo/../other/file.txt")
+    assert not _is_safe_path(root, escape)
+
+
+# -----------------------------------------------------------------------
+# RepoContextProvider — clean repo
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provide_context_clean_git_repo(tmp_path: Path) -> None:
+    """Provide context in a clean git repo returns git + files + artifacts sections."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("# Test repo", encoding="utf-8")
+
+    subprocess.run(
+        ["git", "init", str(repo)],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "Test"],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "."],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "init"],
+        capture_output=True,
+        check=True,
+    )
+
+    ctx = RepoContextProvider(repo)
+    result = await ctx.provide("test-session", "hello")
+
+    assert "Git context" in result
+    assert "Relevant files" in result
+    assert "Artifact references" in result
+    assert "README.md" in result
+
+
+# -----------------------------------------------------------------------
+# RepoContextProvider — dirty worktree
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provide_context_dirty_worktree(tmp_path: Path) -> None:
+    """Uncommitted changes appear in git status output."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("# Test repo", encoding="utf-8")
+
+    subprocess.run(
+        ["git", "init", str(repo)],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "Test"],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "."],
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "init"],
+        capture_output=True,
+        check=True,
+    )
+
+    # Commit change so we can add untracked file
+    (repo / "CHANGELOG.md").write_text("v1.0.0", encoding="utf-8")
+
+    ctx = RepoContextProvider(repo)
+    result = await ctx.provide("test-session", "hello")
+
+    # Untracked file should appear
+    assert "Relevant files" in result
+    assert "CHANGELOG.md" in result or "CHANGELOG" in result
+
+
+# -----------------------------------------------------------------------
+# RepoContextProvider — missing file handling
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provide_context_missing_file_safe() -> None:
+    """Provider does not crash when a tracked file is missing."""
+    ctx = RepoContextProvider("/tmp/nonexistent-repo")
+    result = await ctx.provide("test-session", "hello")
+    # Should not raise; should gracefully handle missing path
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+# -----------------------------------------------------------------------
+# RepoContextProvider — large file truncation
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_file_excerpt_truncation(tmp_path: Path) -> None:
+    """Large files are truncated at max_file_size."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    large_file = repo / "big.txt"
+    large_file.write_bytes(b"A" * 20000)
+
+    ctx = RepoContextProvider(repo, max_file_size=8192)
+    excerpt = ctx._read_file_excerpt(large_file)
+    assert "... [truncated" in excerpt
+    # The content before the truncation message should be at most max_file_size + 1 (newline)
+    content_part = excerpt.split("\n... [truncated")[0]
+    assert len(content_part) == 8192
+
+
+# -----------------------------------------------------------------------
+# RepoContextProvider — non-git repo
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provide_context_non_git_repo(tmp_path: Path) -> None:
+    """A non-git directory still returns context sections."""
+    repo = tmp_path / "no-git"
+    repo.mkdir()
+    (repo / "README.md").write_text("# No git", encoding="utf-8")
+
+    ctx = RepoContextProvider(repo)
+    result = await ctx.provide("test-session", "hello")
+
+    # Should not crash
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+# -----------------------------------------------------------------------
+# RepoContextProvider — scrubbing in provide output
+# -----------------------------------------------------------------------
+
+
+def test_scrub_secrets_removes_github_tokens() -> None:
+    """GitHub personal access tokens are redacted."""
+    text = "token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcd1234"
+    assert "ghp_" not in scrub_secrets(text)
+    assert "[REDACTED]" in scrub_secrets(text)
+
+
+def test_scrub_secrets_preserves_normal_paths() -> None:
+    """Normal file paths are preserved."""
+    text = "src/waywarden/domain/context_provider.py"
+    assert scrub_secrets(text) == text
+
+
+# -----------------------------------------------------------------------
+# RepoContextProvider — repo_root property
+# -----------------------------------------------------------------------
+
+
+def test_repo_root_property_resolves() -> None:
+    ctx = RepoContextProvider("/tmp/test")
+    assert ctx.repo_root == Path("/tmp/test").resolve()
+
+
+# -----------------------------------------------------------------------
+# Artifact references section
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_artifact_references_lists_subdir_contents(tmp_path: Path) -> None:
+    """Artifact references include contents of plans/ artifacts/ directories."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "plans").mkdir()
+    (repo / "plans" / "plan1.md").write_text("plan", encoding="utf-8")
+    (repo / "artifacts").mkdir()
+    (repo / "artifacts" / "diff1.patch").write_text("diff", encoding="utf-8")
+
+    ctx = RepoContextProvider(repo)
+    result = await ctx.provide("test-session", "hello")
+
+    assert "plans/plan1.md" in result
+    assert "artifacts/diff1.patch" in result
+
+
+# -----------------------------------------------------------------------
+# Path safety — symlink escape
+# -----------------------------------------------------------------------
+
+
+def test_is_safe_path_symlink_escape(tmp_path: Path) -> None:
+    """A symlink escaping the repo root is rejected."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    escape = tmp_path / "outside"
+    escape.mkdir()
+    (escape / "file.txt").write_text("xxx", encoding="utf-8")
+
+    # Create a symlink inside repo pointing outside
+    link = repo / "link"
+    link.symlink_to(escape)
+    link_file = link / "file.txt"
+
+    # The symlink target resolves outside — should be unsafe
+    assert not _is_safe_path(repo, link_file)


### PR DESCRIPTION
## Goal
Implement a repo-aware context provider that feeds git + filesystem + artifact-link context into the context pipeline. Provider-neutral; no SDK types leak into the domain layer.

## What Changed
- **New module**: `src/waywarden/domain/context_provider.py`
  - `ContextProvider` protocol — `async def provide(session_id, user_input) -> str`
  - `RepoContextProvider` — produces git status, tracked file list, artifact references
  - `ContextFragment` — composable context block with heading + content
  - `scrub_secrets()` — redacts API keys, tokens, private keys, GitHub PATs
  - `_is_safe_path()` — rejects symlink escapes from repo root

## Tests
21 new tests in `tests/domain/test_context_provider.py`:
- Clean repo, dirty worktree, missing file, non-git repo
- Large file truncation, symlink escape detection
- Secret scrubbing (tokens, keys, keys, passwords)
- Artifact directory listing

## Canonical references
- ADRs: 0001, 0003, 0011
- Depends on: #52 (P3-1), #57 (P3-6), P6-1

Closes #93.